### PR TITLE
chore: simplify issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,82 +1,29 @@
 name: Bug report
-description: Report a bug in Stremio-Web
+description: Something isn't working right
 title: "[Bug]: "
 labels:
   - bug
 body:
-  - type: dropdown
-    id: stremio_web_version
+  - type: input
+    id: environment
     attributes:
-      label: "Stremio-Web Version"
-      description: "Select the version of the Stremio-Web app you are using"
-      options:
-        - /development branch
-        - web.stremio.com
-        - web.strem.io
-    validations:
-      required: true
-
-  - type: dropdown
-    id: browser
-    attributes:
-      label: "Browser"
-      description: "Which browser are you using?"
-      options:
-        - Chrome
-        - Brave
-        - Firefox
-        - Arc
-        - Opera
-        - Safari
-        - Edge
-    validations:
-      required: true
-
-  - type: dropdown
-    id: platform
-    attributes:
-      label: "Platform / Device type"
-      description: "Which platform / device type are you using?"
-      options:
-        - Windows
-        - Linux
-        - MacOS
-        - Android Web
-        - Android PWA
-        - iOS Web
-        - iOS PWA
+      label: "Environment"
+      description: "Browser, OS, device — whatever is relevant"
+      placeholder: "e.g. Chrome on macOS, Firefox on Android..."
     validations:
       required: true
 
   - type: textarea
     id: what_happened
     attributes:
-      label: "What Happened?"
-      description: "Describe the issue you encountered"
-      placeholder: "Explain what you were doing, what you expected to happen, and what actually happened."
+      label: "What happened?"
+      description: "What did you do, what did you expect, and what actually happened?"
+      placeholder: "Steps to reproduce, expected vs actual behavior..."
     validations:
       required: true
 
   - type: textarea
-    id: logs
+    id: extra
     attributes:
-      label: "Logs"
-      description: "Paste any relevant logs here (optional)"
-      render: shell
-
-  - type: textarea
-    id: notes
-    attributes:
-      label: "Notes"
-      description: "Any additional information (optional)"
-
-  - type: checkboxes
-    id: code_of_conduct
-    attributes:
-      label: "Code of Conduct"
-      description: "Please confirm you have read and agree to the Code of Conduct"
-      options:
-        - label: "I agree"
-    validations:
-      required: true
-
+      label: "Anything else?"
+      description: "Logs, screenshots, ideas — whatever might help"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,42 +1,20 @@
 name: Feature request
-description: Suggest a new feature or enhancement for Stremio-Web
+description: Suggest an idea or improvement
 title: "[Feature]: "
 labels:
   - enhancement
 body:
-  - type: markdown
-    attributes:
-      value: "Thank you for your interest in improving Stremio-Web! Please provide as much detail as possible."
-
   - type: textarea
-    id: feature_description
+    id: idea
     attributes:
-      label: "Feature Description"
-      description: "Describe the feature you would like to see implemented. What problem does it solve, or what functionality does it add?"
-      placeholder: "Describe your idea in detail..."
+      label: "What's your idea?"
+      description: "Describe what you'd like to see. Go wild."
+      placeholder: "The more detail the better, but even a rough idea is welcome..."
     validations:
       required: true
 
   - type: textarea
-    id: proposed_solution
+    id: extra
     attributes:
-      label: "Proposed Solution"
-      description: "If you have any thoughts on how this could be implemented or approached, share them here."
-      placeholder: "Suggest possible approaches or solutions..."
-
-  - type: textarea
-    id: additional_context
-    attributes:
-      label: "Additional Context or Screenshots"
-      description: "Add any other context, screenshots, or references that may help us understand the request."
-      placeholder: "Any extra info that might help..."
-
-  - type: checkboxes
-    id: code_of_conduct
-    attributes:
-      label: "Code of Conduct"
-      description: "Please confirm you have read and agree to the Code of Conduct"
-      options:
-        - label: "I agree"
-    validations:
-      required: true
+      label: "Anything else?"
+      description: "Mockups, references, screenshots — anything that helps paint the picture"


### PR DESCRIPTION
Removes the old Stremio-Web branding and rigid dropdowns. Replaces them with simple, open-ended fields so people can describe their issue or idea freely without friction.