### PR TITLE
fix: skip shell transport when running inside Tauri

### DIFF
--- a/src/common/useShell.ts
+++ b/src/common/useShell.ts
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react';
 import EventEmitter from 'eventemitter3';
 
 const SHELL_EVENT_OBJECT = 'transport';
-const transport = globalThis?.chrome?.webview;
+const isTauri = !!(globalThis as any).__TAURI_INTERNALS__;
+const transport = isTauri ? null : globalThis?.chrome?.webview;
 const events = new EventEmitter();
 
 enum ShellEventType {


### PR DESCRIPTION
## Summary
- Detect Tauri via `__TAURI_INTERNALS__` and skip `chrome.webview` shell transport
- On Windows, WebView2 exposes `chrome.webview` which makes useShell think it's inside the stremio-service Qt shell, sending IPC messages that Tauri can't parse
- Fixes fullscreen and other shell-related issues in the desktop app