### PR TITLE
fix: play button broken with upcoming/unreleased episodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "react-i18next": "^15.1.3",
         "react-is": "18.3.1",
         "spatial-navigation-polyfill": "github:Stremio/spatial-navigation#64871b1422466f5f45d24ebc8bbd315b2ebab6a6",
-        "stremio-translations": "github:Stremio/stremio-translations#1bfcb6d2a4f37bb647959ba0bbbd1ade1415c2fe",
+        "stremio-translations": "github:Aqu1tain/stremio-translations#d58d7f63ce1fa45728f0f1e794b8cad749c8445d",
         "url": "0.11.4",
         "use-long-press": "^3.2.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: github:Stremio/spatial-navigation#64871b1422466f5f45d24ebc8bbd315b2ebab6a6
         version: https://codeload.github.com/Stremio/spatial-navigation/tar.gz/64871b1422466f5f45d24ebc8bbd315b2ebab6a6
       stremio-translations:
-        specifier: github:Stremio/stremio-translations#1bfcb6d2a4f37bb647959ba0bbbd1ade1415c2fe
-        version: https://codeload.github.com/Stremio/stremio-translations/tar.gz/1bfcb6d2a4f37bb647959ba0bbbd1ade1415c2fe
+        specifier: github:Aqu1tain/stremio-translations#d58d7f63ce1fa45728f0f1e794b8cad749c8445d
+        version: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/d58d7f63ce1fa45728f0f1e794b8cad749c8445d
       url:
         specifier: 0.11.4
         version: 0.11.4
@@ -4141,9 +4141,9 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
-  stremio-translations@https://codeload.github.com/Stremio/stremio-translations/tar.gz/1bfcb6d2a4f37bb647959ba0bbbd1ade1415c2fe:
-    resolution: {tarball: https://codeload.github.com/Stremio/stremio-translations/tar.gz/1bfcb6d2a4f37bb647959ba0bbbd1ade1415c2fe}
-    version: 1.45.0
+  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/d58d7f63ce1fa45728f0f1e794b8cad749c8445d:
+    resolution: {tarball: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/d58d7f63ce1fa45728f0f1e794b8cad749c8445d}
+    version: 1.47.0
 
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -9390,7 +9390,7 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  stremio-translations@https://codeload.github.com/Stremio/stremio-translations/tar.gz/1bfcb6d2a4f37bb647959ba0bbbd1ade1415c2fe: {}
+  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/d58d7f63ce1fa45728f0f1e794b8cad749c8445d: {}
 
   string-length@4.0.2:
     dependencies:

--- a/src/components/MetaPreview/ActionButton/ActionButton.js
+++ b/src/components/MetaPreview/ActionButton/ActionButton.js
@@ -7,7 +7,7 @@ const { default: Icon } = require('stremio/components/Icon');
 const { Button } = require('stremio/components');
 const styles = require('./styles');
 
-const ActionButton = ({ className, icon, label, tooltip, ...props }) => {
+const ActionButton = ({ className, icon, label, ...props }) => {
     return (
         <Button title={label} {...props} className={classnames(className, styles['action-button-container'])}>
             {

--- a/src/components/MetaRow/MetaRow.js
+++ b/src/components/MetaRow/MetaRow.js
@@ -6,7 +6,7 @@ const PropTypes = require('prop-types');
 const classnames = require('classnames');
 const { default: Icon } = require('stremio/components/Icon');
 const { Button, HorizontalScroll } = require('stremio/components');
-const CONSTANTS = require('stremio/common/CONSTANTS');
+
 const useTranslate = require('stremio/common/useTranslate');
 const MetaRowPlaceholder = require('./MetaRowPlaceholder');
 const styles = require('./styles');

--- a/src/components/NavBar/HorizontalNavBar/SearchBar/SearchBar.js
+++ b/src/components/NavBar/HorizontalNavBar/SearchBar/SearchBar.js
@@ -161,6 +161,10 @@ const SearchIconButton = ({ className }) => (
 
 const SearchBarFallback = SearchIconButton;
 
+SearchIconButton.propTypes = {
+    className: PropTypes.string,
+};
+
 SearchBarFallback.propTypes = SearchBar.propTypes;
 
 module.exports = withCoreSuspender(SearchBar, SearchBarFallback);

--- a/src/components/Video/Video.js
+++ b/src/components/Video/Video.js
@@ -60,16 +60,15 @@ const Video = ({ className, id, title, thumbnail, season, episode, released, upc
         closeMenu();
         onMarkSeasonAsWatched(season, seasonWatched);
     }, [season, seasonWatched, onMarkSeasonAsWatched]);
+    const notPlayable = upcoming || !(released instanceof Date) || isNaN(released.getTime());
     const videoButtonOnClick = React.useCallback(() => {
-        if (upcoming || !(released instanceof Date) || isNaN(released.getTime())) return;
-        if (deepLinks) {
-            if (typeof deepLinks.player === 'string') {
-                window.location = deepLinks.player;
-            } else if (typeof deepLinks.metaDetailsStreams === 'string') {
-                window.location.replace(deepLinks.metaDetailsStreams);
-            }
+        if (notPlayable) return;
+        if (typeof deepLinks?.player === 'string') {
+            window.location = deepLinks.player;
+        } else if (typeof deepLinks?.metaDetailsStreams === 'string') {
+            window.location.replace(deepLinks.metaDetailsStreams);
         }
-    }, [upcoming, released, deepLinks]);
+    }, [notPlayable, deepLinks]);
     const renderLabel = React.useMemo(() => function renderLabel({ className, id, title, thumbnail, episode, released, upcoming, watched, progress, scheduled, children, ref, ...props }) {
         const blurThumbnail = profile.settings.hideSpoilers && season && episode && !watched;
 
@@ -86,7 +85,7 @@ const Video = ({ className, id, title, thumbnail, season, episode, released, upc
         }, [selected]);
 
         return (
-            <Button {...props} ref={ref} className={classnames(className, styles['video-container'], { [styles['selected']]: selected, [styles['disabled']]: upcoming || !(released instanceof Date) || isNaN(released.getTime()) })} title={title}>
+            <Button {...props} ref={ref} className={classnames(className, styles['video-container'], { [styles['selected']]: selected, [styles['disabled']]: notPlayable })} title={title}>
                 {
                     typeof thumbnail === 'string' && thumbnail.length > 0 ?
                         <div className={styles['thumbnail-container']}>

--- a/src/components/Video/Video.js
+++ b/src/components/Video/Video.js
@@ -61,6 +61,7 @@ const Video = ({ className, id, title, thumbnail, season, episode, released, upc
         onMarkSeasonAsWatched(season, seasonWatched);
     }, [season, seasonWatched, onMarkSeasonAsWatched]);
     const videoButtonOnClick = React.useCallback(() => {
+        if (upcoming || !(released instanceof Date) || isNaN(released.getTime())) return;
         if (deepLinks) {
             if (typeof deepLinks.player === 'string') {
                 window.location = deepLinks.player;
@@ -68,7 +69,7 @@ const Video = ({ className, id, title, thumbnail, season, episode, released, upc
                 window.location.replace(deepLinks.metaDetailsStreams);
             }
         }
-    }, [deepLinks]);
+    }, [upcoming, released, deepLinks]);
     const renderLabel = React.useMemo(() => function renderLabel({ className, id, title, thumbnail, episode, released, upcoming, watched, progress, scheduled, children, ref, ...props }) {
         const blurThumbnail = profile.settings.hideSpoilers && season && episode && !watched;
 
@@ -85,7 +86,7 @@ const Video = ({ className, id, title, thumbnail, season, episode, released, upc
         }, [selected]);
 
         return (
-            <Button {...props} ref={ref} className={classnames(className, styles['video-container'], { [styles['selected']]: selected })} title={title}>
+            <Button {...props} ref={ref} className={classnames(className, styles['video-container'], { [styles['selected']]: selected, [styles['disabled']]: upcoming || !(released instanceof Date) || isNaN(released.getTime()) })} title={title}>
                 {
                     typeof thumbnail === 'string' && thumbnail.length > 0 ?
                         <div className={styles['thumbnail-container']}>

--- a/src/components/Video/styles.less
+++ b/src/components/Video/styles.less
@@ -177,6 +177,12 @@
         }
     }
 
+    &.disabled {
+        opacity: 0.3;
+        cursor: default;
+        pointer-events: none;
+    }
+
     &.selected {
         animation: border 3s ease-in-out forwards;
     }

--- a/src/routes/MetaDetails/MetaDetails.js
+++ b/src/routes/MetaDetails/MetaDetails.js
@@ -65,6 +65,8 @@ const MetaDetails = ({ urlParams, queryParams }) => {
     const seriesPlayAction = React.useMemo(() => {
         if (!hasVideos || !isReady) return null;
 
+        const isReleased = (v) => !v.upcoming && v.released instanceof Date && !isNaN(v.released.getTime());
+
         const sorted = [...meta.videos].sort((a, b) => {
             if ((a.season ?? 0) !== (b.season ?? 0)) return (a.season ?? 0) - (b.season ?? 0);
             return (a.episode ?? 0) - (b.episode ?? 0);
@@ -78,16 +80,16 @@ const MetaDetails = ({ urlParams, queryParams }) => {
                 if (!resumeVideo.watched) {
                     const href = resumeVideo.deepLinks?.player ?? resumeVideo.deepLinks?.metaDetailsStreams ?? null;
                     const label = resumeVideo.season != null
-                        ? `Resume S${resumeVideo.season} E${resumeVideo.episode}`
-                        : `Resume E${resumeVideo.episode}`;
+                        ? `${t('LIBRARY_RESUME')} S${resumeVideo.season} E${resumeVideo.episode}`
+                        : `${t('LIBRARY_RESUME')} E${resumeVideo.episode}`;
                     return { label, href };
                 }
-                const nextUnwatched = sorted.slice(resumeIdx + 1).find((v) => !v.watched && !v.upcoming);
+                const nextUnwatched = sorted.slice(resumeIdx + 1).find((v) => !v.watched && isReleased(v));
                 if (nextUnwatched) {
                     const href = nextUnwatched.deepLinks?.player ?? nextUnwatched.deepLinks?.metaDetailsStreams ?? null;
                     const label = nextUnwatched.season != null
-                        ? `Play S${nextUnwatched.season} E${nextUnwatched.episode}`
-                        : `Play E${nextUnwatched.episode}`;
+                        ? `${t('LIBRARY_PLAY')} S${nextUnwatched.season} E${nextUnwatched.episode}`
+                        : `${t('LIBRARY_PLAY')} E${nextUnwatched.episode}`;
                     return { label, href };
                 }
             }
@@ -95,14 +97,15 @@ const MetaDetails = ({ urlParams, queryParams }) => {
 
         const nonSpecials = sorted.filter((v) => v.season !== 0);
         const candidates = nonSpecials.length > 0 ? nonSpecials : sorted;
-        const firstUnwatched = candidates.find((v) => !v.watched && !v.upcoming);
-        const target = firstUnwatched ?? candidates[0];
+        const firstUnwatched = candidates.find((v) => !v.watched && isReleased(v));
+        const target = firstUnwatched ?? candidates.find((v) => isReleased(v)) ?? null;
         if (!target) return null;
 
         const href = target.deepLinks?.player ?? target.deepLinks?.metaDetailsStreams ?? null;
+        const verb = firstUnwatched ? t('LIBRARY_PLAY') : t('LIBRARY_REWATCH');
         const label = target.season != null
-            ? `Play S${target.season} E${target.episode}`
-            : `Play E${target.episode}`;
+            ? `${verb} S${target.season} E${target.episode}`
+            : `${verb} E${target.episode}`;
         return { label, href };
     }, [hasVideos, isReady, meta, metaDetails.libraryItem]);
 
@@ -298,7 +301,7 @@ const MetaDetails = ({ urlParams, queryParams }) => {
                             {!hasVideos && typeof firstStreamHref === 'string' &&
                                 <Button className={styles['play-button']} href={firstStreamHref}>
                                     <Icon className={styles['play-icon']} name={'play'} />
-                                    <span>Play</span>
+                                    <span>{t('LIBRARY_PLAY')}</span>
                                 </Button>
                             }
                             {typeof meta.inLibrary === 'boolean' &&

--- a/src/routes/MetaDetails/MetaDetails.js
+++ b/src/routes/MetaDetails/MetaDetails.js
@@ -1,6 +1,6 @@
 const React = require('react');
 const PropTypes = require('prop-types');
-const classnames = require('classnames');
+
 const { useTranslation } = require('react-i18next');
 const { default: Icon } = require('stremio/components/Icon');
 const { default: Button } = require('stremio/components/Button');
@@ -30,7 +30,7 @@ const MetaDetails = ({ urlParams, queryParams }) => {
     const { core } = useServices();
     const metaDetails = useMetaDetails(urlParams);
     const [season, setSeason] = useSeason(urlParams, queryParams);
-    const [extensionTabs, metaExtension, clearMetaExtension] = useMetaExtensionTabs(metaDetails.metaExtensions);
+    const [, metaExtension, clearMetaExtension] = useMetaExtensionTabs(metaDetails.metaExtensions);
     const [shareModalOpen, openShareModal, closeShareModal] = useBinaryState(false);
     const [activeTab, setActiveTab] = React.useState('streams');
 
@@ -69,7 +69,7 @@ const MetaDetails = ({ urlParams, queryParams }) => {
         const hrefOf = (v) => v.deepLinks?.player ?? v.deepLinks?.metaDetailsStreams ?? null;
         const makeAction = (verb, video) => ({
             href: hrefOf(video),
-            label: video.season != null
+            label: video.season !== null
                 ? `${verb} S${video.season} E${video.episode}`
                 : `${verb} E${video.episode}`,
         });

--- a/src/routes/MetaDetails/MetaDetails.js
+++ b/src/routes/MetaDetails/MetaDetails.js
@@ -66,6 +66,13 @@ const MetaDetails = ({ urlParams, queryParams }) => {
         if (!hasVideos || !isReady) return null;
 
         const isReleased = (v) => !v.upcoming && v.released instanceof Date && !isNaN(v.released.getTime());
+        const hrefOf = (v) => v.deepLinks?.player ?? v.deepLinks?.metaDetailsStreams ?? null;
+        const makeAction = (verb, video) => ({
+            href: hrefOf(video),
+            label: video.season != null
+                ? `${verb} S${video.season} E${video.episode}`
+                : `${verb} E${video.episode}`,
+        });
 
         const sorted = [...meta.videos].sort((a, b) => {
             if ((a.season ?? 0) !== (b.season ?? 0)) return (a.season ?? 0) - (b.season ?? 0);
@@ -77,21 +84,9 @@ const MetaDetails = ({ urlParams, queryParams }) => {
             const resumeIdx = sorted.findIndex((v) => v.id === libraryVideoId);
             if (resumeIdx !== -1) {
                 const resumeVideo = sorted[resumeIdx];
-                if (!resumeVideo.watched) {
-                    const href = resumeVideo.deepLinks?.player ?? resumeVideo.deepLinks?.metaDetailsStreams ?? null;
-                    const label = resumeVideo.season != null
-                        ? `${t('LIBRARY_RESUME')} S${resumeVideo.season} E${resumeVideo.episode}`
-                        : `${t('LIBRARY_RESUME')} E${resumeVideo.episode}`;
-                    return { label, href };
-                }
+                if (!resumeVideo.watched) return makeAction(t('LIBRARY_RESUME'), resumeVideo);
                 const nextUnwatched = sorted.slice(resumeIdx + 1).find((v) => !v.watched && isReleased(v));
-                if (nextUnwatched) {
-                    const href = nextUnwatched.deepLinks?.player ?? nextUnwatched.deepLinks?.metaDetailsStreams ?? null;
-                    const label = nextUnwatched.season != null
-                        ? `${t('LIBRARY_PLAY')} S${nextUnwatched.season} E${nextUnwatched.episode}`
-                        : `${t('LIBRARY_PLAY')} E${nextUnwatched.episode}`;
-                    return { label, href };
-                }
+                if (nextUnwatched) return makeAction(t('LIBRARY_PLAY'), nextUnwatched);
             }
         }
 
@@ -101,12 +96,8 @@ const MetaDetails = ({ urlParams, queryParams }) => {
         const target = firstUnwatched ?? candidates.find((v) => isReleased(v)) ?? null;
         if (!target) return null;
 
-        const href = target.deepLinks?.player ?? target.deepLinks?.metaDetailsStreams ?? null;
         const verb = firstUnwatched ? t('LIBRARY_PLAY') : t('LIBRARY_REWATCH');
-        const label = target.season != null
-            ? `${verb} S${target.season} E${target.episode}`
-            : `${verb} E${target.episode}`;
-        return { label, href };
+        return makeAction(verb, target);
     }, [hasVideos, isReady, meta, metaDetails.libraryItem]);
 
     const trailerHref = React.useMemo(() => {
@@ -287,7 +278,7 @@ const MetaDetails = ({ urlParams, queryParams }) => {
                             <div className={styles['hero-description-container']}>
                                 <div ref={descriptionRef} className={styles['hero-description']}>{description}</div>
                                 {descriptionTruncated &&
-                                    <Button className={styles['see-more']} onClick={showDetails}>See more</Button>
+                                    <Button className={styles['see-more']} onClick={showDetails}>{t('SHOW_MORE')}</Button>
                                 }
                             </div>
                         }

--- a/src/routes/MetaDetails/StreamsList/StreamsList.js
+++ b/src/routes/MetaDetails/StreamsList/StreamsList.js
@@ -203,7 +203,7 @@ const StreamsList = ({ className, video, type, onEpisodeSearch, ...props }) => {
                                                 className={classnames(styles['quality-filter-chip'], { [styles['active']]: qualityFilter === null })}
                                                 onClick={() => setQualityFilter(null)}
                                             >
-                                                All
+                                                {t('ALL')}
                                             </button>
                                             {availableQualities.map((label) => (
                                                 <button


### PR DESCRIPTION
## Summary

The play button in MetaDetails would select upcoming or dateless (TBA) episodes when all released episodes were watched, resulting in a broken or unresponsive button. Now it skips unplayable episodes entirely, dims them visually at 30% opacity with pointer-events disabled, and shows "Rewatch S1 E1" (translated) when there's nothing new to play.

Uses a forked stremio-translations with the new LIBRARY_REWATCH key across 50 languages.

Closes #10