### PR TITLE
feat: support Tauri auto-update in UpdaterBanner

### DIFF
--- a/src/App/UpdaterBanner/UpdaterBanner.less
+++ b/src/App/UpdaterBanner/UpdaterBanner.less
@@ -1,46 +1,103 @@
 .updater-banner {
-    height: 4rem;
     display: flex;
     align-items: center;
-    justify-content: center;
     gap: 1rem;
-    padding: 0 1rem;
-    font-size: 1rem;
-    font-weight: bold;
-    color: var(--primary-foreground-color);
-    background-color: var(--primary-accent-color);
+    padding: 1rem 1.25rem;
+    margin: 0 1rem 1rem;
+    background-color: var(--modal-background-color);
+    border-radius: var(--border-radius);
+    border: var(--overlay-border);
+    backdrop-filter: blur(10px);
+    box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.48), 0 0.5rem 3rem rgba(0, 0, 0, 0.64);
 
-    .button {
+    .icon-container {
+        flex: none;
         display: flex;
-        flex-direction: row;
         align-items: center;
         justify-content: center;
+        width: 2.5rem;
         height: 2.5rem;
-        padding: 0 1rem;
-        border-radius: var(--border-radius);
-        color: var(--primary-background-color);
-        background-color: var(--primary-foreground-color);
-        transition: all 0.1s ease-out;
+        border-radius: 0.5rem;
+        background-color: var(--primary-accent-color);
 
-        &:hover {
-            color: var(--primary-foreground-color);
-            background-color: transparent;
-            box-shadow: inset 0 0 0 0.15rem var(--primary-foreground-color);
+        .icon {
+            width: 1.25rem;
+            height: 1.25rem;
+            color: white;
         }
     }
 
-    .close {
-        position: absolute;
-        right: 0;
-        height: 4rem;
-        width: 4rem;
+    .content {
+        flex: 1;
+        min-width: 0;
+
+        .title {
+            font-size: 1.1rem;
+            font-weight: 600;
+            color: var(--primary-foreground-color);
+        }
+
+        .version {
+            font-size: 0.95rem;
+            color: var(--primary-foreground-color);
+            opacity: 0.6;
+            margin-top: 0.1rem;
+        }
+    }
+
+    .install-button {
+        flex: none;
+        position: relative;
         display: flex;
-        flex-direction: row;
         align-items: center;
         justify-content: center;
+        height: 2.5rem;
+        padding: 0 1.25rem;
+        border-radius: 0.5rem;
+        font-size: 1rem;
+        font-weight: 600;
+        color: white;
+        background-color: var(--primary-accent-color);
+        overflow: hidden;
+        transition: opacity 0.15s ease-out;
 
-        .icon {
-            height: 2rem;
+        &:hover {
+            opacity: 0.85;
+        }
+
+        &:global(.disabled) {
+            opacity: 0.7;
+        }
+    }
+
+    .progress-bar {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        height: 3px;
+        background-color: rgba(255, 255, 255, 0.5);
+        transition: width 0.3s ease-out;
+    }
+
+    .close-button {
+        flex: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 2rem;
+        height: 2rem;
+        border-radius: 0.375rem;
+
+        .close-icon {
+            width: 1.1rem;
+            height: 1.1rem;
+            color: var(--primary-foreground-color);
+            opacity: 0.4;
+            transition: opacity 0.15s ease-out;
+        }
+
+        &:hover .close-icon {
+            opacity: 1;
         }
     }
 }

--- a/src/App/UpdaterBanner/UpdaterBanner.tsx
+++ b/src/App/UpdaterBanner/UpdaterBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import Icon from 'stremio/components/Icon';
 import { useTranslation } from 'react-i18next';
 import { useServices } from 'stremio/services';
@@ -10,36 +10,83 @@ type Props = {
     className: string,
 };
 
+const isTauri = !!(globalThis as any).__TAURI_INTERNALS__;
+
+const invoke = (cmd: string, args?: Record<string, unknown>) =>
+    (window as any).__TAURI_INTERNALS__.invoke(cmd, args || {});
+
 const UpdaterBanner = ({ className }: Props) => {
     const { t } = useTranslation();
     const { shell } = useServices();
     const shellTransport = useShell();
     const [visible, show, hide] = useBinaryState(false);
+    const [installing, setInstalling] = useState(false);
+    const [version, setVersion] = useState('');
+    const [progress, setProgress] = useState<number | null>(null);
 
-    const onInstallClick = () => {
-        shellTransport.send('autoupdater-notif-clicked');
-    };
+    const onInstallClick = useCallback(() => {
+        if (isTauri) {
+            setInstalling(true);
+            invoke('install_update').catch(() => setInstalling(false));
+        } else {
+            shellTransport.send('autoupdater-notif-clicked');
+        }
+    }, [shellTransport]);
 
     useEffect(() => {
-        shell.transport && shell.transport.on('autoupdater-show-notif', show);
+        if (isTauri) {
+            const onUpdateAvailable = (e: CustomEvent) => {
+                const detail = typeof e.detail === 'string' ? JSON.parse(e.detail) : e.detail;
+                setVersion(detail.version || '');
+                show();
+            };
 
-        return () => {
-            shell.transport && shell.transport.off('autoupdater-show-notif', show);
-        };
+            const onUpdateProgress = (e: CustomEvent) => {
+                const detail = typeof e.detail === 'string' ? JSON.parse(e.detail) : e.detail;
+                if (detail.total > 0) {
+                    setProgress(Math.round((detail.downloaded / detail.total) * 100));
+                }
+            };
+
+            window.addEventListener('stremio-update-available', onUpdateAvailable as EventListener);
+            window.addEventListener('stremio-update-progress', onUpdateProgress as EventListener);
+
+            return () => {
+                window.removeEventListener('stremio-update-available', onUpdateAvailable as EventListener);
+                window.removeEventListener('stremio-update-progress', onUpdateProgress as EventListener);
+            };
+        }
+
+        shell.transport?.on('autoupdater-show-notif', show);
+        return () => { shell.transport?.off('autoupdater-show-notif', show); };
     }, []);
 
     return (
         <div className={className}>
             <Transition when={visible} name={'slide-up'}>
                 <div className={styles['updater-banner']}>
-                    <div className={styles['label']}>
-                        { t('UPDATER_TITLE') }
+                    <div className={styles['icon-container']}>
+                        <Icon className={styles['icon']} name={'download'} />
                     </div>
-                    <Button className={styles['button']} onClick={onInstallClick}>
-                        { t('UPDATER_INSTALL_BUTTON') }
+                    <div className={styles['content']}>
+                        <div className={styles['title']}>
+                            {version
+                                ? `${t('UPDATER_TITLE')} — v${version}`
+                                : t('UPDATER_TITLE')
+                            }
+                        </div>
+                    </div>
+                    <Button className={styles['install-button']} onClick={onInstallClick} disabled={installing}>
+                        {installing
+                            ? progress !== null ? `${progress}%` : 'Installing…'
+                            : t('UPDATER_INSTALL_BUTTON')
+                        }
+                        {installing && progress !== null ? (
+                            <div className={styles['progress-bar']} style={{ width: `${progress}%` }} />
+                        ) : null}
                     </Button>
-                    <Button className={styles['close']} onClick={hide}>
-                        <Icon className={styles['icon']} name={'close'} />
+                    <Button className={styles['close-button']} onClick={hide}>
+                        <Icon className={styles['close-icon']} name={'close'} />
                     </Button>
                 </div>
             </Transition>


### PR DESCRIPTION
## Summary

Rewrites UpdaterBanner to support both Tauri and Qt shell transports. In Tauri, listens for CustomEvents from the Rust backend to show the banner with version info, handles install via Tauri command, and tracks download progress. Redesigned to match the app's glass-morphism style.