### PR TITLE
chore: bump stremio-translations to 1c232aa5

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "react-i18next": "^15.1.3",
         "react-is": "18.3.1",
         "spatial-navigation-polyfill": "github:Stremio/spatial-navigation#64871b1422466f5f45d24ebc8bbd315b2ebab6a6",
-        "stremio-translations": "github:Aqu1tain/stremio-translations#4e9d8497",
+        "stremio-translations": "github:Aqu1tain/stremio-translations#1c232aa5",
         "url": "0.11.4",
         "use-long-press": "^3.2.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: github:Stremio/spatial-navigation#64871b1422466f5f45d24ebc8bbd315b2ebab6a6
         version: https://codeload.github.com/Stremio/spatial-navigation/tar.gz/64871b1422466f5f45d24ebc8bbd315b2ebab6a6
       stremio-translations:
-        specifier: github:Aqu1tain/stremio-translations#4e9d8497
-        version: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/4e9d8497
+        specifier: github:Aqu1tain/stremio-translations#1c232aa5
+        version: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/1c232aa5
       url:
         specifier: 0.11.4
         version: 0.11.4
@@ -4211,8 +4211,8 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
-  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/4e9d8497:
-    resolution: {tarball: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/4e9d8497}
+  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/1c232aa5:
+    resolution: {tarball: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/1c232aa5}
     version: 1.47.0
 
   string-length@4.0.2:
@@ -9561,7 +9561,7 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/4e9d8497: {}
+  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/1c232aa5: {}
 
   string-length@4.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

Updates stremio-translations to include native UPDATER_TITLE translations for all locales with the Stremio Horizon rename.