### PR TITLE
fix(build): set Terser ecma target to 2020

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -195,7 +195,7 @@ module.exports = (env, argv) => ({
                 test: /\.js$/,
                 extractComments: false,
                 terserOptions: {
-                    ecma: 5,
+                    ecma: 2020,
                     mangle: true,
                     warnings: false,
                     output: {


### PR DESCRIPTION
## Summary

The Terser minifier was configured with `ecma: 5`, which downleveled ES module interop patterns in a way that broke at runtime. This caused the addons page (and potentially other pages using TS modules with default exports) to crash in production builds with `C is not a function` errors.

Changing the target to `ecma: 2020` preserves the module patterns correctly. All modern browsers and Tauri's WebKit engine support ES2020+, so there's no compatibility concern.

Closes #32

## Test plan

- Production build tested in Chrome — addons page loads correctly
- Production build tested in Tauri macOS app — addons page loads correctly

---
## EntelligenceAI PR Summary 
 This PR updates the Terser minifier configuration in `webpack.config.js` to target ECMAScript 2020, enabling modern JavaScript optimizations during the build process.
- Changed `ecma` option in Terser minification config from `5` to `2020`
- Allows Terser to leverage ES2020 syntax features for potentially smaller and more optimized output bundles 


---

## Confidence Score: 2/5 - Changes Needed

- The change from `ecma: 5` to `ecma: 2020` in Terser config is a significant compatibility issue — it allows Terser to emit ES2020 syntax in the minified output, which will break in older browsers/environments that don't support it.
- This is a build configuration bug with broad impact: it could silently break the application for users on older browsers without obvious error messages during development.
- The issue is not cosmetic — it affects the runtime behavior of the compiled output and could cause widespread failures in production.

<details>
<summary>Files requiring special attention</summary>

- `webpack.config.js`

</details>
