### PR TITLE
feat(settings): add version labels

### DIFF
--- a/src/routes/Settings/Info/Info.tsx
+++ b/src/routes/Settings/Info/Info.tsx
@@ -28,19 +28,22 @@ const Info = ({ streamingServer }: Props) => {
 
     return (
         <Section className={styles['info']} label={'SETTINGS_ABOUT'}>
-            <Option label={t('SETTINGS_APP_VERSION')}>
+            <Option label={'Stremio Horizon'}>
                 <div className={styles['label']}>
                     {process.env.VERSION}
                 </div>
             </Option>
-            <Option label={t('SETTINGS_BUILD_VERSION')}>
-                <div className={styles['option-content']}>
-                    <div className={styles['label']}>
-                        {process.env.COMMIT_HASH}
-                    </div>
-                    <Button className={styles['copy-button']} title={t('COPY')} onClick={onCopyHash}>
-                        <Icon className={styles['copy-icon']} name={copied ? 'checkmark' : 'copy'} />
-                    </Button>
+            {
+                typeof shell?.transport?.props?.shellVersion === 'string' &&
+                    <Option label={'Stremio Horizon App'}>
+                        <div className={styles['label']}>
+                            {shell.transport.props.shellVersion}
+                        </div>
+                    </Option>
+            }
+            <Option label={'Stremio Core'}>
+                <div className={styles['label']}>
+                    {process.env.CORE_VERSION}
                 </div>
             </Option>
             {
@@ -51,14 +54,16 @@ const Info = ({ streamingServer }: Props) => {
                         </div>
                     </Option>
             }
-            {
-                typeof shell?.transport?.props?.shellVersion === 'string' &&
-                    <Option label={t('SETTINGS_SHELL_VERSION')}>
-                        <div className={styles['label']}>
-                            {shell.transport.props.shellVersion}
-                        </div>
-                    </Option>
-            }
+            <Option label={t('SETTINGS_BUILD_VERSION')}>
+                <div className={styles['option-content']}>
+                    <div className={styles['label']}>
+                        {process.env.COMMIT_HASH}
+                    </div>
+                    <Button className={styles['copy-button']} title={t('COPY')} onClick={onCopyHash}>
+                        <Icon className={styles['copy-icon']} name={copied ? 'checkmark' : 'copy'} />
+                    </Button>
+                </div>
+            </Option>
         </Section>
     );
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const WorkboxPlugin = require('workbox-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const packageJson = require('./package.json');
+const coreWebPackageJson = require('@stremio/stremio-core-web/package.json');
 
 const COMMIT_HASH = execSync('git rev-parse HEAD').toString().trim();
 
@@ -215,6 +216,7 @@ module.exports = (env, argv) => ({
             SERVICE_WORKER_DISABLED: false,
             DEBUG: argv.mode !== 'production',
             VERSION: packageJson.version,
+            CORE_VERSION: coreWebPackageJson.version,
             COMMIT_HASH
         }),
         new webpack.ProvidePlugin({


### PR DESCRIPTION
## Summary

Reworked the About section in Settings to show all relevant versions: Stremio Horizon (frontend), Stremio Horizon App (Tauri shell, conditional), Stremio Core, Server, and Build hash.

The Core version is injected at build time from the `@stremio/stremio-core-web` package.json. The App version only shows when running inside the Tauri shell.

---
## EntelligenceAI PR Summary 
 This PR updates the Settings Info version display and wires up the Stremio Core version as a build-time constant.
- Added `CORE_VERSION` global via `webpack.DefinePlugin`, sourced from `@stremio/stremio-core-web/package.json`
- Replaced `SETTINGS_APP_VERSION` translation key with hardcoded `'Stremio Horizon'` label in `Info.tsx`
- Replaced `SETTINGS_SHELL_VERSION` translation key with hardcoded `'Stremio Horizon App'` label in `Info.tsx`
- Added new 'Stremio Core' version entry rendering `process.env.CORE_VERSION` in `Info.tsx`
- Reordered version entries: Stremio Horizon → Stremio Horizon App → Stremio Core → Server Version → Build Version 


---

## Confidence Score: 5/5 - Safe to Merge

- No review comments were generated, indicating the PR appears clean with no identified issues.
- All changed files (2/2) were reviewed with no critical, significant, or medium issues found.
- Heuristic analysis confirms maximum allowed score of 5/5 with zero issues across all severity levels.
