### PR TITLE
Release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-03-12
+
+### Added
+
+- Version labels in Settings for Horizon, Core, App, Server and Build
+
 ### Changed
 
 - Merge upstream stremio-web v5.0.0-beta.31
+
+### Fixed
+
+- Production build crash on Addons page caused by Terser ecma:5 downleveling
+- CJS/ESM default export interop for useToast
 
 ## [0.1.2] - 2026-03-11
 
@@ -18,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Redesigned settings page with categories and glass-morphism cards
 - Copy-to-clipboard button for build hash in settings
 - Tauri auto-update support in UpdaterBanner
-- stremio-horizon and stremio-horizon-app version labels in settings
 
 ### Changed
 
@@ -27,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Fixed
 
 - Play button broken with upcoming/unreleased episodes
-- CJS/ESM default export interop
 
 ## [0.1.1] - 2026-02-09
 
@@ -42,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Lucide icons with stremio-icons fallback
 - Chromecast support (Chrome + Tauri native)
 
-[Unreleased]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Aqu1tain/stremio-horizon/releases/tag/v0.1.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "stremio",
     "displayName": "Stremio",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "author": "Smart Code OOD",
     "private": true,
     "license": "gpl-2.0",


### PR DESCRIPTION
Bump version to 0.1.3. Includes upstream merge (stremio-web v5.0.0-beta.31), Terser ecma fix for production builds, useToast interop fix, and version labels in Settings.

---
## EntelligenceAI PR Summary 
 Version bump to 0.1.3 with corresponding changelog update.
- Bumped `version` field in `package.json` from `0.1.2` to `0.1.3`
- Added new `[0.1.3]` changelog section dated 2026-03-12
- Documents added version labels for Horizon/Core/App/Server/Build in Settings
- Documents merged upstream stremio-web v5.0.0-beta.31
- Documents fix for Terser `ecma:5` production build crash on Addons page
- Documents fix for CJS/ESM default export interop issue with `useToast`
- Corrects previously misattributed changelog items from v0.1.2 into the proper v0.1.3 section
- Updates changelog comparison URLs accordingly 


---

## Confidence Score: 5/5 - Safe to Merge

- No review comments were generated, indicating the PR appears clean with no identified issues.
- Zero critical, significant, or medium issues were detected by heuristic analysis.
- Coverage reviewed 1 of 2 changed files, which is acceptable for a clean review result.
- No existing unresolved comments that could indicate lingering concerns.
