### PR TITLE
fix(app): guard focus handler against null transport

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -193,7 +193,7 @@ const App = () => {
         return () => {
             if (coreReady) {
                 window.removeEventListener('focus', onWindowFocus);
-                services.core.transport.off('CoreEvent', onCoreEvent);
+                services.core.transport?.off('CoreEvent', onCoreEvent);
             }
         };
     }, [initialized, shell.windowClosed]);

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -185,7 +185,7 @@ const App = () => {
                 }
             });
         };
-        if (services.core.active) {
+        if (services.core.active && services.core.transport) {
             onWindowFocus();
             window.addEventListener('focus', onWindowFocus);
             services.core.transport.on('CoreEvent', onCoreEvent);

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -64,13 +64,7 @@ const App = () => {
         };
     }, []);
     React.useEffect(() => {
-        const onCoreStateChanged = () => {
-            setInitialized(
-                (services.core.active || services.core.error instanceof Error) &&
-                (services.shell.active || services.shell.error instanceof Error)
-            );
-        };
-        const onShellStateChanged = () => {
+        const onServiceStateChanged = () => {
             setInitialized(
                 (services.core.active || services.core.error instanceof Error) &&
                 (services.shell.active || services.shell.error instanceof Error)
@@ -87,8 +81,8 @@ const App = () => {
                 });
             }
         };
-        services.core.on('stateChanged', onCoreStateChanged);
-        services.shell.on('stateChanged', onShellStateChanged);
+        services.core.on('stateChanged', onServiceStateChanged);
+        services.shell.on('stateChanged', onServiceStateChanged);
         services.chromecast.on('stateChanged', onChromecastStateChange);
         services.core.start();
         services.shell.start();
@@ -102,8 +96,8 @@ const App = () => {
             services.chromecast.stop();
             services.keyboardShortcuts.stop();
             services.dragAndDrop.stop();
-            services.core.off('stateChanged', onCoreStateChanged);
-            services.shell.off('stateChanged', onShellStateChanged);
+            services.core.off('stateChanged', onServiceStateChanged);
+            services.shell.off('stateChanged', onServiceStateChanged);
             services.chromecast.off('stateChanged', onChromecastStateChange);
         };
     }, []);

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -153,7 +153,7 @@ const App = () => {
             }
         };
         const onWindowFocus = () => {
-            if (!services.core.transport) return;
+            if (!services.core.active || !services.core.transport) return;
             services.core.transport.dispatch({
                 action: 'Ctx',
                 args: {
@@ -180,7 +180,8 @@ const App = () => {
                 }
             });
         };
-        if (services.core.active && services.core.transport) {
+        const coreReady = services.core.active && services.core.transport;
+        if (coreReady) {
             onWindowFocus();
             window.addEventListener('focus', onWindowFocus);
             services.core.transport.on('CoreEvent', onCoreEvent);
@@ -190,7 +191,7 @@ const App = () => {
                 .catch(console.error);
         }
         return () => {
-            if (services.core.active && services.core.transport) {
+            if (coreReady) {
                 window.removeEventListener('focus', onWindowFocus);
                 services.core.transport.off('CoreEvent', onCoreEvent);
             }

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -159,6 +159,7 @@ const App = () => {
             }
         };
         const onWindowFocus = () => {
+            if (!services.core.transport) return;
             services.core.transport.dispatch({
                 action: 'Ctx',
                 args: {

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -195,7 +195,7 @@ const App = () => {
                 .catch(console.error);
         }
         return () => {
-            if (services.core.active) {
+            if (services.core.active && services.core.transport) {
                 window.removeEventListener('focus', onWindowFocus);
                 services.core.transport.off('CoreEvent', onCoreEvent);
             }


### PR DESCRIPTION
## Summary

When the core transport errors out mid-session (network issue, wasm crash), `transport` is set to null while the focus event listener is still attached. Focusing the Stremio window after that calls `.dispatch()` on null and crashes the app. This adds a null check on `services.core.transport` before attaching the listener.

Fixes #39

---
## EntelligenceAI PR Summary 
 This PR adds a defensive null-check for `services.core.transport` in `App.js` to prevent runtime errors when the transport object is undefined.
- Added `services.core.transport` null-check in `src/App/App.js`
- Guards the `.on('CoreEvent', ...)` call from being invoked on an undefined transport
- Complements the existing `services.core.active` condition check

---

## Confidence Score: 5/5 - Safe to Merge

- No review comments were generated, indicating the PR appears clean with no detected issues.
- All changed files were reviewed (1/1 coverage) with no critical, significant, or medium issues found.
- No existing unresolved comments that could indicate lingering problems.
- Heuristic analysis supports a maximum score of 5/5 with zero issues across all severity levels.