### PR TITLE
fix(chromecast): remove CastContext listeners on cleanup

### DIFF
--- a/src/services/Chromecast/ChromecastTransport.js
+++ b/src/services/Chromecast/ChromecastTransport.js
@@ -122,6 +122,17 @@ function ChromecastTransport() {
     };
     this.removeAllListeners = function() {
         events.removeAllListeners();
+        const ctx = cast?.framework?.CastContext?.getInstance();
+        if (ctx) {
+            ctx.removeEventListener(
+                cast.framework.CastContextEventType.CAST_STATE_CHANGED,
+                onCastStateChanged
+            );
+            ctx.removeEventListener(
+                cast.framework.CastContextEventType.SESSION_STATE_CHANGED,
+                onSesstionStateChanged
+            );
+        }
     };
     this.getCastState = function() {
         return cast.framework.CastContext.getInstance().getCastState();

--- a/src/services/Chromecast/ChromecastTransport.js
+++ b/src/services/Chromecast/ChromecastTransport.js
@@ -122,17 +122,10 @@ function ChromecastTransport() {
     };
     this.removeAllListeners = function() {
         events.removeAllListeners();
-        const ctx = cast?.framework?.CastContext?.getInstance();
-        if (ctx) {
-            ctx.removeEventListener(
-                cast.framework.CastContextEventType.CAST_STATE_CHANGED,
-                onCastStateChanged
-            );
-            ctx.removeEventListener(
-                cast.framework.CastContextEventType.SESSION_STATE_CHANGED,
-                onSesstionStateChanged
-            );
-        }
+        if (!castAPIAvailable) return;
+        const ctx = cast.framework.CastContext.getInstance();
+        ctx.removeEventListener(cast.framework.CastContextEventType.CAST_STATE_CHANGED, onCastStateChanged);
+        ctx.removeEventListener(cast.framework.CastContextEventType.SESSION_STATE_CHANGED, onSesstionStateChanged);
     };
     this.getCastState = function() {
         return cast.framework.CastContext.getInstance().getCastState();


### PR DESCRIPTION
## Summary

`ChromecastTransport.removeAllListeners()` only cleared the internal EventEmitter but never removed the two listeners added on `CastContext` during `initialize()` (CAST_STATE_CHANGED, SESSION_STATE_CHANGED). Each start/stop cycle leaked two more listeners. This adds proper cleanup matching the pattern already used in `TauriChromecastTransport`.

## Test plan

- App loads without console errors
- Chromecast service start/stop does not accumulate listeners

---
## EntelligenceAI PR Summary 
 Fixes potential memory leaks in `ChromecastTransport` by ensuring all `CastContext` event listeners are removed during transport teardown.
- Extended `removeAllListeners` in `ChromecastTransport` to deregister `CAST_STATE_CHANGED` and `SESSION_STATE_CHANGED` events from the `CastContext` instance
- Applied optional chaining (`?.`) for safe access when `CastContext` may be unavailable
- Prevents stale event handlers from persisting after transport destruction

---

## Confidence Score: 5/5 - Safe to Merge

- No review comments were generated, indicating the PR appears clean with no identified issues.
- All changed files were reviewed (1/1 coverage) with no critical, significant, or medium issues found.
- No existing unresolved comments that could indicate lingering concerns.
- Heuristic analysis supports a maximum score of 5/5 with zero issues across all severity levels.