### PR TITLE
fix: correct Lithuanian ISO 639-2 code

### DIFF
--- a/src/common/interfaceLanguages.json
+++ b/src/common/interfaceLanguages.json
@@ -101,7 +101,7 @@
     },
     {
         "name": "Lietuvių",
-        "codes": ["lt-LT", "ltu"]
+        "codes": ["lt-LT", "lit"]
     },
     {
         "name": "македонски јазик",


### PR DESCRIPTION
## Summary

The Lithuanian entry in interfaceLanguages.json used `ltu` as the ISO 639-2 code, which doesn't exist. The correct ISO 639-2/B code is `lit`. This caused language matching to fail for Lithuanian users.