### PR TITLE
chore: bump stremio-translations fork to v1.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Changed
 
 - Merge upstream stremio-web v5.0.0-beta.36
+- Bump stremio-translations fork to v1.52.0 (gamepad guide, magnet copy, playback speed strings)
 - Code splitting with lazy route imports
 - Avatar images converted from PNG to WebP
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "react-i18next": "^15.1.3",
         "react-is": "18.3.1",
         "spatial-navigation-polyfill": "github:Stremio/spatial-navigation#64871b1422466f5f45d24ebc8bbd315b2ebab6a6",
-        "stremio-translations": "github:Aqu1tain/stremio-translations#1c232aa5",
+        "stremio-translations": "github:Aqu1tain/stremio-translations#ccbee922",
         "url": "0.11.4",
         "use-long-press": "^3.2.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: github:Stremio/spatial-navigation#64871b1422466f5f45d24ebc8bbd315b2ebab6a6
         version: https://codeload.github.com/Stremio/spatial-navigation/tar.gz/64871b1422466f5f45d24ebc8bbd315b2ebab6a6
       stremio-translations:
-        specifier: github:Aqu1tain/stremio-translations#1c232aa5
-        version: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/1c232aa5
+        specifier: github:Aqu1tain/stremio-translations#ccbee922
+        version: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/ccbee922
       url:
         specifier: 0.11.4
         version: 0.11.4
@@ -4211,9 +4211,9 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
-  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/1c232aa5:
-    resolution: {tarball: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/1c232aa5}
-    version: 1.47.0
+  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/ccbee922:
+    resolution: {tarball: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/ccbee922}
+    version: 1.52.0
 
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -9561,7 +9561,7 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/1c232aa5: {}
+  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/ccbee922: {}
 
   string-length@4.0.2:
     dependencies:


### PR DESCRIPTION
Rebases the Aqu1tain/stremio-translations fork onto upstream v1.52.0 and bumps the pin in horizon's package.json to the new SHA. Brings in the strings introduced upstream since v1.47.0 — gamepad guide, magnet copy, playback speed shortcuts, video scale, subtitle context menu — so the new beta.36 features render their actual labels instead of falling back to translation keys. Horizon-specific commits (Chromecast picker, updater title rename, LIBRARY_REWATCH) preserved on top of 1.52.0 with conflicts resolved (kept upstream's better Italian/Bulgarian/Arabic prose where it diverged from Horizon's English-fallback strings).