### PR TITLE
feat(tauri): introduce stremio/lib/tauri-events wrapper

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,6 +54,14 @@ export default [
                     'error'
                 ]
             }],
+            'no-restricted-imports': ['error', {
+                paths: [
+                    {
+                        name: '@tauri-apps/api/event',
+                        message: 'Use listenTauri from stremio/lib/tauri-events instead.'
+                    }
+                ]
+            }],
         }
     },
     {

--- a/src/App/UpdaterBanner/UpdaterBanner.tsx
+++ b/src/App/UpdaterBanner/UpdaterBanner.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useServices } from 'stremio/services';
 import { useBinaryState, useShell, useToast } from 'stremio/common';
 import { Button, Transition } from 'stremio/components';
-import { invokeTauri, isTauri, listenTauri } from 'stremio/common/tauri';
+import { invokeTauri, isTauri, listenTauri } from 'stremio/lib/tauri-events';
 import styles from './UpdaterBanner.less';
 
 type Props = {

--- a/src/lib/tauri-events.ts
+++ b/src/lib/tauri-events.ts
@@ -1,0 +1,2 @@
+export { invokeTauri, isTauri, listenTauri } from 'stremio/common/tauri';
+export type { TauriEvent } from 'stremio/common/tauri';

--- a/src/routes/Settings/General/General.tsx
+++ b/src/routes/Settings/General/General.tsx
@@ -6,7 +6,7 @@ import { usePlatform, useToast } from 'stremio/common';
 import { Category, Section, Option, Link } from '../components';
 import User from './User';
 import useDataExport from './useDataExport';
-import { invokeTauri, isTauri } from 'stremio/common/tauri';
+import { invokeTauri, isTauri } from 'stremio/lib/tauri-events';
 import styles from './General.less';
 
 type Props = {


### PR DESCRIPTION
Adds a thin re-export of invokeTauri, listenTauri, isTauri, and TauriEvent at src/lib/tauri-events.ts. The new path is the sanctioned import for any module that needs to invoke or listen to Tauri commands. src/common/tauri.ts stays where it is so existing imports do not break. Updates the two current callers (UpdaterBanner.tsx and Settings/General.tsx) and adds an ESLint no-restricted-imports rule banning @tauri-apps/api/event so future code does not bypass the wrapper. No runtime change: listenTauri already routes Tauri-emitted events through the same handler.