### PR TITLE
chore: version 0.1.5-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "stremio",
     "displayName": "Stremio",
-    "version": "0.1.4",
+    "version": "0.1.5-rc.1",
     "upstreamVersion": "v5.0.0-beta.39",
     "author": "Smart Code OOD",
     "private": true,


### PR DESCRIPTION
Version bump for the first release candidate carrying the beta.39 upstream merge, Picture-in-Picture and the hls.js recovery patch. The app repo builds its own pre-release from this tag's stremio-web.zip so the changes can be tested on macOS, Windows and Linux.