### PR TITLE
chore: release 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-07-31
+
 ### Added
 
 - Picture-in-Picture button in the player control bar, shown only when the active video
@@ -106,7 +108,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Lucide icons with stremio-icons fallback
 - Chromecast support (Chrome + Tauri native)
 
-[Unreleased]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.1...v0.1.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# Stremio Horizon
+
+React frontend for Stremio. Uses webpack, LESS with CSS modules, CommonJS `require()` (not ES imports). JSX lives in `.js` files, newer components use `.tsx`.
+
+## Dev commands
+
+```bash
+pnpm start          # dev server (skips Terser — won't catch minification bugs)
+pnpm start-prod     # dev server with production config
+pnpm build          # production build → build/
+pnpm test           # jest
+pnpm lint           # eslint
+```
+
+## Architecture
+
+- `src/services/Core/` — WASM worker bridge to stremio-core-web
+- `src/services/Shell/` — Tauri/Qt shell detection and IPC
+- `src/routes/` — page components (Discover, Addons, Player, Settings, etc.)
+- `src/common/` — shared hooks, constants, utilities
+- Components use `@stremio/stremio-colors` LESS vars and CSS modules (hash:base64:5)
+- Path alias: `stremio/*` → `src/*`
+- Icons: `lucide-react` mapped in `Icon.tsx`
+
+## Key patterns
+
+- Modal: `ModalDialog` from `stremio/components`
+- Binary state: `useBinaryState(false)` → `[value, on, off, toggle]`
+- Services: `useServices()` → `{ chromecast, core, shell }`
+- Tauri detection: `typeof window.__TAURI_INTERNALS__ !== 'undefined'`
+
+## Build gotchas
+
+- Terser must use `ecma: 2020` — ecma:5 breaks ES module interop at runtime
+- Commit hash is embedded in output paths for cache busting
+- Service worker (Workbox) precaches assets < 20MB
+- `@stremio/stremio-core-web` runs in a Web Worker, not main thread
+
+## Branch workflow
+
+- Default branch: `development`
+- PRs target `development` only; `main` merges come from `development`
+- Branch protection enabled — no direct pushes
+- Conventional commits, atomic changes
+- Always update CHANGELOG.md when releasing

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "stremio",
     "displayName": "Stremio",
-    "version": "0.1.5-rc.1",
+    "version": "0.1.5",
     "upstreamVersion": "v5.0.0-beta.39",
     "author": "Smart Code OOD",
     "private": true,


### PR DESCRIPTION
Promotes the release candidate to 0.1.5 and closes the changelog section for it. No code change since v0.1.5-rc.1.