### PR TITLE
feat(streams): keep loading addons visible

### DIFF
--- a/src/routes/MetaDetails/StreamsList/Stream/StreamPlaceholder/StreamPlaceholder.js
+++ b/src/routes/MetaDetails/StreamsList/Stream/StreamPlaceholder/StreamPlaceholder.js
@@ -6,11 +6,18 @@ const classnames = require('classnames');
 const PlayIconCircleCentered = require('./PlayIconCircleCentered');
 const styles = require('./styles');
 
-const StreamPlaceholder = ({ className }) => {
+const StreamPlaceholder = ({ className, addonName }) => {
+    const hasAddonName = typeof addonName === 'string' && addonName.length > 0;
+
     return (
         <div className={classnames(className, styles['stream-placeholder-container'])}>
             <div className={styles['addon-container']}>
-                <div className={styles['addon-name']} />
+                <div
+                    className={classnames(styles['addon-name'], { [styles['addon-name-placeholder']]: !hasAddonName })}
+                    title={hasAddonName ? addonName : undefined}
+                >
+                    {hasAddonName ? addonName : null}
+                </div>
             </div>
             <div className={styles['info-container']}>
                 <div className={styles['description-container']} />
@@ -22,7 +29,8 @@ const StreamPlaceholder = ({ className }) => {
 };
 
 StreamPlaceholder.propTypes = {
-    className: PropTypes.string
+    className: PropTypes.string,
+    addonName: PropTypes.string
 };
 
 module.exports = StreamPlaceholder;

--- a/src/routes/MetaDetails/StreamsList/Stream/StreamPlaceholder/styles.less
+++ b/src/routes/MetaDetails/StreamsList/Stream/StreamPlaceholder/styles.less
@@ -15,10 +15,22 @@
         flex: none;
 
         .addon-name {
+            max-width: 8rem;
+            overflow: hidden;
+            color: var(--primary-foreground-color);
+            font-size: 0.85rem;
+            font-weight: 600;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            opacity: 0.75;
+        }
+
+        .addon-name-placeholder {
             width: 5rem;
             height: 2rem;
             border-radius: var(--border-radius);
             background-color: var(--color-placeholder-background);
+            opacity: 1;
         }
     }
 

--- a/src/routes/MetaDetails/StreamsList/StreamsList.js
+++ b/src/routes/MetaDetails/StreamsList/StreamsList.js
@@ -11,6 +11,7 @@ const { Button, Image, MultiselectMenu } = require('stremio/components');
 const { useCore } = require('stremio/core');
 const { default: parseStreamBadges } = require('stremio/common/parseStreamBadges');
 const Stream = require('./Stream');
+const getStreamsListStatus = require('./getStreamsListStatus');
 const styles = require('./styles');
 const { usePlatform, useProfile } = require('stremio/common');
 const { default: SeasonEpisodePicker } = require('../EpisodePicker');
@@ -43,9 +44,10 @@ const StreamsList = ({ className, video, type, onEpisodeSearch, ...props }) => {
             navigate(-1);
         }
     }, [video]);
-    const countLoadingAddons = React.useMemo(() => {
-        return props.streams.filter((stream) => stream.content.type === 'Loading').length;
+    const loadingAddons = React.useMemo(() => {
+        return props.streams.filter((stream) => stream.content.type === 'Loading');
     }, [props.streams]);
+    const countLoadingAddons = loadingAddons.length;
     const streamsByAddon = React.useMemo(() => {
         return props.streams
             .filter((streams) => streams.content.type === 'Ready')
@@ -112,6 +114,15 @@ const StreamsList = ({ className, video, type, onEpisodeSearch, ...props }) => {
             return badges.some(({ label }) => label === qualityFilter);
         });
     }, [filteredStreams, qualityFilter]);
+    const status = React.useMemo(() => {
+        return getStreamsListStatus(props.streams, filteredStreams);
+    }, [props.streams, filteredStreams]);
+    const loadingPlaceholders = loadingAddons.map(({ addon }, index) => (
+        <Stream.Placeholder
+            key={addon.transportUrl ?? index}
+            addonName={addon.manifest.name}
+        />
+    ));
 
     const handleEpisodePicker = React.useCallback((season, episode) => {
         onEpisodeSearch(season, episode);
@@ -146,7 +157,7 @@ const StreamsList = ({ className, video, type, onEpisodeSearch, ...props }) => {
                 }
             </div>
             {
-                props.streams.length === 0 ?
+                status === 'no-addons' ?
                     <div className={styles['message-container']}>
                         {
                             type === 'series' ?
@@ -157,7 +168,7 @@ const StreamsList = ({ className, video, type, onEpisodeSearch, ...props }) => {
                         <div className={styles['label']}>{t('ERR_NO_ADDONS_FOR_STREAMS')}</div>
                     </div>
                     :
-                    props.streams.every((streams) => streams.content.type === 'Err') ?
+                    status === 'no-streams' ?
                         <div className={styles['message-container']}>
                             {
                                 type === 'series' ?
@@ -182,10 +193,9 @@ const StreamsList = ({ className, video, type, onEpisodeSearch, ...props }) => {
                             }
                         </div>
                         :
-                        filteredStreams.length === 0 ?
+                        status === 'loading' && filteredStreams.length === 0 ?
                             <div className={styles['streams-container']}>
-                                <Stream.Placeholder />
-                                <Stream.Placeholder />
+                                {loadingPlaceholders}
                             </div>
                             :
                             <React.Fragment>
@@ -237,6 +247,9 @@ const StreamsList = ({ className, video, type, onEpisodeSearch, ...props }) => {
                                             onClick={stream.onClick}
                                         />
                                     ))}
+                                    {status === 'loading' &&
+                                        loadingPlaceholders
+                                    }
                                     {
                                         showInstallAddonsButton ?
                                             <Button className={styles['install-button-container']} title={t('ADDON_CATALOGUE_MORE')} href={'#/addons'}>

--- a/src/routes/MetaDetails/StreamsList/getStreamsListStatus.js
+++ b/src/routes/MetaDetails/StreamsList/getStreamsListStatus.js
@@ -1,0 +1,10 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const getStreamsListStatus = (streams, visibleStreams) => {
+    if (streams.length === 0) return 'no-addons';
+    if (streams.some((stream) => stream.content.type === 'Loading')) return 'loading';
+    if (visibleStreams.length === 0) return 'no-streams';
+    return 'ready';
+};
+
+module.exports = getStreamsListStatus;

--- a/tests/getStreamsListStatus.spec.js
+++ b/tests/getStreamsListStatus.spec.js
@@ -1,0 +1,32 @@
+const getStreamsListStatus = require('../src/routes/MetaDetails/StreamsList/getStreamsListStatus');
+
+describe('getStreamsListStatus', () => {
+    test('reports that no addons were requested', () => {
+        expect(getStreamsListStatus([], [])).toBe('no-addons');
+    });
+
+    test('keeps loading while at least one addon is pending', () => {
+        const streams = [
+            { content: { type: 'Ready', content: [{ name: 'Available stream' }] } },
+            { content: { type: 'Loading' } },
+        ];
+
+        expect(getStreamsListStatus(streams, streams[0].content.content)).toBe('loading');
+    });
+
+    test('reports no streams only after every addon has settled', () => {
+        const streams = [
+            { content: { type: 'Ready', content: [] } },
+            { content: { type: 'Err', error: new Error('Unavailable') } },
+        ];
+
+        expect(getStreamsListStatus(streams, [])).toBe('no-streams');
+    });
+
+    test('reports ready when settled addons returned streams', () => {
+        const visibleStreams = [{ name: 'Available stream' }];
+        const streams = [{ content: { type: 'Ready', content: visibleStreams } }];
+
+        expect(getStreamsListStatus(streams, visibleStreams)).toBe('ready');
+    });
+});


### PR DESCRIPTION
## What changed

- keep the Streams section populated with skeleton rows while addons are still loading
- label each pending skeleton with the addon name
- preserve already available streams while slower addons continue loading
- show the empty state only after every requested addon has settled

## Why

Slow addons could leave users without enough context about whether stream discovery was still progressing or which providers were pending. The loading state now stays visible and identifies each pending addon.

## Validation

- ESLint
- Jest: 100 tests passed
- production webpack build
- local macOS release build tested