### PR TITLE
fix: clarify AllDebrid VPN playback failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "react-router": "6.30.0",
         "react-router-dom": "6.30.0",
         "spatial-navigation-polyfill": "github:Stremio/spatial-navigation#64871b1422466f5f45d24ebc8bbd315b2ebab6a6",
-        "stremio-translations": "github:Aqu1tain/stremio-translations#81b62fc4",
+        "stremio-translations": "github:Aqu1tain/stremio-translations#34bbda0b0888cb5dfe6cde21444f162c1ce60e68",
         "url": "0.11.4",
         "use-long-press": "^3.3.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: github:Stremio/spatial-navigation#64871b1422466f5f45d24ebc8bbd315b2ebab6a6
         version: https://codeload.github.com/Stremio/spatial-navigation/tar.gz/64871b1422466f5f45d24ebc8bbd315b2ebab6a6
       stremio-translations:
-        specifier: github:Aqu1tain/stremio-translations#81b62fc4
-        version: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/81b62fc4d23be1a5d91851867ce69c808121beb6
+        specifier: github:Aqu1tain/stremio-translations#34bbda0b0888cb5dfe6cde21444f162c1ce60e68
+        version: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/34bbda0b0888cb5dfe6cde21444f162c1ce60e68
       url:
         specifier: 0.11.4
         version: 0.11.4
@@ -4763,8 +4763,8 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
-  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/81b62fc4d23be1a5d91851867ce69c808121beb6:
-    resolution: {gitHosted: true, integrity: sha512-mqHUGlIMhVJXNfu6b6q9KaBrb3fTOUv1EYRJKEq5xrcNli1FSbAb3HHuYeFSB5eyTfOjMphRqXEe7gdXAHYiUA==, tarball: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/81b62fc4d23be1a5d91851867ce69c808121beb6}
+  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/34bbda0b0888cb5dfe6cde21444f162c1ce60e68:
+    resolution: {gitHosted: true, integrity: sha512-XhZKyhTlTPWxECIVLHJZTqbL5sxGZJ9nGj/NRPf+zDJmBywvmX8/WE6ynlr6bmDE6B86+bWurKJDOGoaz0duXg==, tarball: https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/34bbda0b0888cb5dfe6cde21444f162c1ce60e68}
     version: 1.53.2
 
   string-length@4.0.2:
@@ -10767,7 +10767,7 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/81b62fc4d23be1a5d91851867ce69c808121beb6: {}
+  stremio-translations@https://codeload.github.com/Aqu1tain/stremio-translations/tar.gz/34bbda0b0888cb5dfe6cde21444f162c1ce60e68: {}
 
   string-length@4.0.2:
     dependencies:

--- a/src/routes/Player/Error/Error.js
+++ b/src/routes/Player/Error/Error.js
@@ -6,10 +6,15 @@ const PropTypes = require('prop-types');
 const classNames = require('classnames');
 const { default: Icon } = require('stremio/components/Icon');
 const { Button } = require('stremio/components');
+const shouldShowAllDebridVpnHint = require('./shouldShowAllDebridVpnHint');
 const styles = require('./styles');
 
-const Error = React.forwardRef(({ className, code, message, stream }, ref) => {
+const ALLDEBRID_VPN_HELP_URL = 'https://alldebrid.com/vpn';
+
+const Error = React.forwardRef(({ className, code, message, sourceStream, stream }, ref) => {
     const { t } = useTranslation();
+    const showAllDebridVpnHint = shouldShowAllDebridVpnHint(code, stream) ||
+        shouldShowAllDebridVpnHint(code, sourceStream);
 
     const [playlist, fileName] = React.useMemo(() => {
         return [
@@ -24,6 +29,27 @@ const Error = React.forwardRef(({ className, code, message, stream }, ref) => {
             {
                 code === 2 ?
                     <div className={styles['error-sub']} title={t('EXTERNAL_PLAYER_HINT')}>{t('EXTERNAL_PLAYER_HINT')}</div>
+                    :
+                    null
+            }
+            {
+                showAllDebridVpnHint ?
+                    <div className={styles['vpn-hint']}>
+                        <div
+                            className={styles['error-sub']}
+                            title={t('PLAYER_ALLDEBRID_VPN_HINT')}
+                        >
+                            {t('PLAYER_ALLDEBRID_VPN_HINT')}
+                        </div>
+                        <Button
+                            className={styles['vpn-help-button']}
+                            title={t('PLAYER_ALLDEBRID_VPN_HELP')}
+                            href={ALLDEBRID_VPN_HELP_URL}
+                            target={'_blank'}
+                        >
+                            {t('PLAYER_ALLDEBRID_VPN_HELP')}
+                        </Button>
+                    </div>
                     :
                     null
             }
@@ -50,6 +76,7 @@ Error.propTypes = {
     className: PropTypes.string,
     code: PropTypes.number,
     message: PropTypes.string,
+    sourceStream: PropTypes.object,
     stream: PropTypes.object,
 };
 

--- a/src/routes/Player/Error/shouldShowAllDebridVpnHint.js
+++ b/src/routes/Player/Error/shouldShowAllDebridVpnHint.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const ALLDEBRID_HOSTNAMES = [
+    'alldebrid.com',
+    'debrid.it',
+];
+
+const isAllDebridUrl = (value) => {
+    if (typeof value !== 'string' || value.length === 0) {
+        return false;
+    }
+
+    try {
+        const { hostname } = new URL(value);
+
+        return ALLDEBRID_HOSTNAMES.some((allDebridHostname) => {
+            return hostname === allDebridHostname || hostname.endsWith(`.${allDebridHostname}`);
+        });
+    } catch (_error) {
+        return false;
+    }
+};
+
+const shouldShowAllDebridVpnHint = (code, stream) => {
+    if (code !== 4) {
+        return false;
+    }
+
+    const externalPlayer = stream?.deepLinks?.externalPlayer;
+    const urls = [
+        stream?.url,
+        stream?.externalUrl,
+        externalPlayer?.streaming,
+        externalPlayer?.download,
+        externalPlayer?.playlist,
+    ];
+
+    return urls.some(isAllDebridUrl);
+};
+
+module.exports = shouldShowAllDebridVpnHint;

--- a/src/routes/Player/Error/styles.less
+++ b/src/routes/Player/Error/styles.less
@@ -28,6 +28,28 @@
         text-align: center;            
     }
 
+    .vpn-hint {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .vpn-help-button {
+        flex: none;
+        margin-top: 1rem;
+        padding: 0.6rem 1.2rem;
+        border-radius: 2rem;
+        background-color: var(--secondary-accent-color);
+        font-size: 1.1rem;
+        font-weight: 500;
+        color: var(--primary-foreground-color);
+
+        &:hover {
+            outline: var(--focus-outline-size) solid var(--secondary-accent-color);
+            background-color: transparent;
+        }
+    }
+
     .playlist-button {
         flex: none;
         display: flex;

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -1010,7 +1010,8 @@ const Player = () => {
                     <Error
                         ref={errorRef}
                         className={classnames(styles['layer'], styles['error-layer'])}
-                        stream={video.state.stream}
+                        stream={video.state.stream ?? (player.stream?.type === 'Ready' ? player.stream.content : player.selected?.stream)}
+                        sourceStream={player.stream?.type === 'Ready' ? player.stream.content : player.selected?.stream}
                         {...error}
                     />
                     :

--- a/tests/playerError.spec.js
+++ b/tests/playerError.spec.js
@@ -1,0 +1,74 @@
+/** @jest-environment jsdom */
+
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const React = require('react');
+const { describe, expect, jest, test } = require('@jest/globals');
+const { render, screen } = require('@testing-library/react');
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key) => ({
+            PLAYER_ALLDEBRID_VPN_HINT: 'This AllDebrid stream may be blocked by your VPN or current IP address.',
+            PLAYER_ALLDEBRID_VPN_HELP: 'Open AllDebrid VPN help',
+        })[key] ?? key,
+    }),
+}));
+
+jest.mock('stremio/components/Icon', () => ({
+    default: () => null,
+}));
+
+jest.mock('stremio/components', () => {
+    const React = require('react');
+    const PropTypes = require('prop-types');
+    const Button = ({ children, ...props }) => React.createElement('a', props, children);
+
+    Button.propTypes = {
+        children: PropTypes.node,
+    };
+
+    return {
+        Button,
+    };
+});
+
+jest.mock('../src/routes/Player/Error/styles', () => ({}), { virtual: true });
+
+const PlayerError = require('../src/routes/Player/Error/Error');
+
+describe('Player Error', () => {
+    test('shows the AllDebrid VPN hint for an unsupported AllDebrid stream', () => {
+        render(React.createElement(PlayerError, {
+            code: 4,
+            message: 'Video not supported',
+            stream: { url: 'https://ombfyx.debrid.it/file/movie.mp4' },
+        }));
+
+        expect(screen.getByText(/may be blocked by your VPN/i)).toBeTruthy();
+        expect(screen.getByRole('link', { name: 'Open AllDebrid VPN help' }).getAttribute('href'))
+            .toBe('https://alldebrid.com/vpn');
+    });
+
+    test('keeps the generic error for unsupported non-AllDebrid streams', () => {
+        render(React.createElement(PlayerError, {
+            code: 4,
+            message: 'Video not supported',
+            stream: { url: 'https://example.com/file/movie.mp4' },
+        }));
+
+        expect(screen.getByText('Video not supported')).toBeTruthy();
+        expect(screen.queryByText(/may be blocked by your VPN/i)).toBeNull();
+    });
+
+    test('uses the original stream when playback has been proxied locally', () => {
+        render(React.createElement(PlayerError, {
+            code: 4,
+            message: 'Video not supported',
+            stream: { url: 'http://127.0.0.1:11470/proxy/movie.mp4' },
+            sourceStream: { url: 'https://ombfyx.debrid.it/file/movie.mp4' },
+        }));
+
+        expect(screen.getByText(/may be blocked by your VPN/i)).toBeTruthy();
+    });
+});

--- a/tests/shouldShowAllDebridVpnHint.spec.js
+++ b/tests/shouldShowAllDebridVpnHint.spec.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const shouldShowAllDebridVpnHint = require('../src/routes/Player/Error/shouldShowAllDebridVpnHint');
+
+describe('shouldShowAllDebridVpnHint', () => {
+    test('recognizes unsupported AllDebrid streams', () => {
+        expect(shouldShowAllDebridVpnHint(4, {
+            url: 'https://ombfyx.debrid.it/file/movie.mp4',
+        })).toBe(true);
+    });
+
+    test('recognizes AllDebrid URLs in external player deep links', () => {
+        expect(shouldShowAllDebridVpnHint(4, {
+            deepLinks: {
+                externalPlayer: {
+                    streaming: 'https://media.alldebrid.com/file/movie.mp4',
+                },
+            },
+        })).toBe(true);
+    });
+
+    test('does not attribute other media errors to a VPN', () => {
+        expect(shouldShowAllDebridVpnHint(2, {
+            url: 'https://ombfyx.debrid.it/file/movie.mp4',
+        })).toBe(false);
+    });
+
+    test('does not attribute unsupported non-AllDebrid streams to a VPN', () => {
+        expect(shouldShowAllDebridVpnHint(4, {
+            url: 'https://example.com/file/movie.mp4',
+        })).toBe(false);
+    });
+
+    test('does not trust hostnames that only contain an AllDebrid domain', () => {
+        expect(shouldShowAllDebridVpnHint(4, {
+            url: 'https://debrid.it.evil.example/file/movie.mp4',
+        })).toBe(false);
+    });
+
+    test('handles missing and malformed stream URLs', () => {
+        expect(shouldShowAllDebridVpnHint(4, null)).toBe(false);
+        expect(shouldShowAllDebridVpnHint(4, { url: 'not a URL' })).toBe(false);
+    });
+});


### PR DESCRIPTION
## What changed

- detect unsupported playback failures tied to AllDebrid URLs
- keep the generic media error and add a cautious VPN/IP hint with the official AllDebrid help link
- inspect both the active player URL and the original stream so local proxying does not hide the provider
- add English/French translations with English fallback for other locales
- add deterministic classifier and rendered UI tests

## Root cause

The browser exposes the blocked AllDebrid response as a generic media error, so users only saw “video not supported”. The player did not preserve any provider-specific guidance in the error UI.

## Validation

- 109 Jest tests pass
- ESLint passes
- production webpack build passes
- tested in a real Tauri release with no visible regression

Fixes #17