### PR TITLE
feat(auth): redesign login and registration flow

### DIFF
--- a/src/components/Checkbox/Checkbox.less
+++ b/src/components/Checkbox/Checkbox.less
@@ -11,19 +11,22 @@
         display: flex;
         flex-direction: row;
         align-items: center;
+        width: 100%;
         padding: 0.5rem 0;
         cursor: pointer;
         
         span {
             font-size: 0.9rem;
+            line-height: 1.4;
             color: var(--primary-foreground-color);
-            opacity: 0.6;
+            opacity: 0.82;
         }
 
         .link {
             font-size: 0.9rem;
+            line-height: 1.4;
             color: var(--primary-accent-color);
-            margin-left: 0.5rem;
+            margin-left: 0.35rem;
 
             &:hover {
                 text-decoration: underline;
@@ -40,7 +43,7 @@
         padding: 0.1rem;
         display: flex;
         flex: none;
-        margin: 0 1rem 0 0.3rem;
+        margin: 0 0.75rem 0 0.1rem;
         align-items: center;
         justify-content: center;
         transition: background-color 0.2s ease-in-out;
@@ -52,10 +55,12 @@
         outline-offset: 2px;
 
         input[type='checkbox'] {
+            inset: 0;
             opacity: 0;
-            width: 0;
-            height: 0;
+            width: 100%;
+            height: 100%;
             position: absolute;
+            margin: 0;
             cursor: pointer;
         }
 
@@ -77,7 +82,7 @@
             background-color: var(--primary-accent-color);
         }
 
-        &:hover, &:focus {
+        &:hover, &:focus-within {
             outline-style: solid;
         }
     }

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,6 @@
 // Copyright (C) 2017-2025 Smart code 203358507
 
-import React, { useCallback, ChangeEvent, KeyboardEvent, RefCallback } from 'react';
+import React, { useCallback, ChangeEvent, RefCallback } from 'react';
 import classNames from 'classnames';
 import styles from './Checkbox.less';
 import Button from '../Button';
@@ -18,7 +18,7 @@ type Props = {
     onChange?: (props: {
         type: string;
         checked: boolean;
-        reactEvent: KeyboardEvent<HTMLInputElement> | ChangeEvent<HTMLInputElement>;
+        reactEvent: ChangeEvent<HTMLInputElement>;
         nativeEvent: Event;
     }) => void;
     error?: string;
@@ -37,17 +37,6 @@ const Checkbox = React.forwardRef<HTMLInputElement, Props>(({ name, disabled, cl
         }
     }, [disabled, onChange]);
 
-    const onKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
-        if ((event.key === 'Enter' || event.key === ' ') && !disabled) {
-            onChange && onChange({
-                type: 'select',
-                checked: !checked,
-                reactEvent: event as KeyboardEvent<HTMLInputElement>,
-                nativeEvent: event.nativeEvent,
-            });
-        }
-    }, [disabled, checked, onChange]);
-
     return (
         <div className={classNames(styles['checkbox'], className)}>
             <label className={styles['label']} htmlFor={name}>
@@ -58,14 +47,11 @@ const Checkbox = React.forwardRef<HTMLInputElement, Props>(({ name, disabled, cl
                         { [styles['disabled']]: disabled },
                         { [styles['error']]: error }
                     )}
-                    role={'checkbox'}
-                    tabIndex={disabled ? -1 : 0}
-                    aria-checked={checked}
-                    onKeyDown={onKeyDown}
                 >
                     <input
                         ref={ref}
                         id={name}
+                        name={name}
                         type={'checkbox'}
                         checked={checked}
                         disabled={disabled}
@@ -79,10 +65,10 @@ const Checkbox = React.forwardRef<HTMLInputElement, Props>(({ name, disabled, cl
                     }
                 </div>
                 <div>
-                    <span>{label}</span>
+                    <span>{label}{href && link ? ' ' : null}</span>
                     {
                         href && link ?
-                            <Button className={styles['link']} href={href} target={'_blank'} tabIndex={-1}>
+                            <Button className={styles['link']} href={href} target={'_blank'}>
                                 {link}
                             </Button>
                             : null

--- a/src/routes/Intro/Intro.js
+++ b/src/routes/Intro/Intro.js
@@ -9,7 +9,7 @@ const Modal = require('stremio/router/Modal');
 const { useCore } = require('stremio/core');
 const { useBinaryState } = require('stremio/common');
 const { default: useRouteFocused } = require('stremio/common/useRouteFocused');
-const { Button, Image, Checkbox } = require('stremio/components');
+const { Image, Checkbox } = require('stremio/components');
 const CredentialsTextInput = require('./CredentialsTextInput');
 const PasswordResetModal = require('./PasswordResetModal');
 const useFacebookLogin = require('./useFacebookLogin');
@@ -44,7 +44,7 @@ const Intro = () => {
                     if (state.form !== action.form) {
                         return {
                             form: action.form,
-                            email: '',
+                            email: state.email,
                             password: '',
                             confirmPassword: '',
                             termsAccepted: false,
@@ -108,10 +108,6 @@ const Intro = () => {
                 dispatch({ type: 'error', error: error.message });
             });
     }, []);
-    const cancelLoginWithFacebook = React.useCallback(() => {
-        stopFacebookLogin();
-        closeLoaderModal();
-    }, []);
     const loginWithApple = React.useCallback(() => {
         openLoaderModal();
         startAppleLogin()
@@ -134,10 +130,6 @@ const Intro = () => {
                 closeLoaderModal();
                 dispatch({ type: 'error', error: error.message });
             });
-    }, []);
-    const cancelLoginWithApple = React.useCallback(() => {
-        stopAppleLogin();
-        closeLoaderModal();
     }, []);
     const loginWithEmail = React.useCallback(() => {
         if (typeof state.email !== 'string' || state.email.length === 0 || !emailRef.current.validity.valid) {
@@ -215,7 +207,8 @@ const Intro = () => {
             value: event.currentTarget.value
         });
     }, []);
-    const emailOnSubmit = React.useCallback(() => {
+    const emailOnSubmit = React.useCallback((event) => {
+        event.preventDefault();
         passwordRef.current.focus();
     }, []);
     const passwordOnChange = React.useCallback((event) => {
@@ -225,13 +218,12 @@ const Intro = () => {
             value: event.currentTarget.value
         });
     }, []);
-    const passwordOnSubmit = React.useCallback(() => {
+    const passwordOnSubmit = React.useCallback((event) => {
         if (state.form === SIGNUP_FORM) {
+            event.preventDefault();
             confirmPasswordRef.current.focus();
-        } else {
-            loginWithEmail();
         }
-    }, [state.form, loginWithEmail]);
+    }, [state.form]);
     const confirmPasswordOnChange = React.useCallback((event) => {
         dispatch({
             type: 'change-credentials',
@@ -239,7 +231,8 @@ const Intro = () => {
             value: event.currentTarget.value
         });
     }, []);
-    const confirmPasswordOnSubmit = React.useCallback(() => {
+    const confirmPasswordOnSubmit = React.useCallback((event) => {
+        event.preventDefault();
         termsRef.current.focus();
     }, []);
     const toggleTermsAccepted = React.useCallback(() => {
@@ -251,10 +244,19 @@ const Intro = () => {
     const toggleMarketingAccepted = React.useCallback(() => {
         dispatch({ type: 'toggle-checkbox', name: 'marketingAccepted' });
     }, []);
-    const switchFormOnClick = React.useCallback(() => {
-        const queryParams = new URLSearchParams([['form', state.form === SIGNUP_FORM ? LOGIN_FORM : SIGNUP_FORM]]);
+    const switchForm = React.useCallback((form) => {
+        const queryParams = new URLSearchParams([['form', form]]);
         setQueryParams(queryParams);
-    }, [state.form]);
+    }, []);
+    const formOnSubmit = React.useCallback((event) => {
+        event.preventDefault();
+        state.form === SIGNUP_FORM ? signup() : loginWithEmail();
+    }, [state.form, signup, loginWithEmail]);
+    const cancelAuthentication = React.useCallback(() => {
+        stopFacebookLogin();
+        stopAppleLogin();
+        closeLoaderModal();
+    }, []);
     React.useEffect(() => {
         if ([LOGIN_FORM, SIGNUP_FORM].includes(queryParams.get('form'))) {
             dispatch({ type: 'set-form', form: queryParams.get('form') });
@@ -282,6 +284,10 @@ const Intro = () => {
         const onCoreError = (source) => {
             if (source.event === 'UserAuthenticated') {
                 closeLoaderModal();
+                dispatch({
+                    type: 'error',
+                    error: t(state.form === SIGNUP_FORM ? 'SIGNUP_FAILED' : 'LOGIN_FAILED')
+                });
             }
         };
         core.on('event', onCoreEvent);
@@ -290,126 +296,176 @@ const Intro = () => {
             core.off('event', onCoreEvent);
             core.off('error', onCoreError);
         };
-    }, [routeFocused]);
+    }, [routeFocused, state.form]);
     return (
         <div className={styles['intro-container']}>
             <div className={styles['background-container']} />
             <div className={styles['heading-container']}>
                 <div className={styles['logo-container']}>
-                    <Image className={styles['logo']} src={require('/assets/images/logo.png')} alt={' '} />
+                    <Image className={styles['logo']} src={require('/assets/images/logo.png')} alt={'Stremio'} />
                 </div>
-                <div className={styles['title-container']}>
+                <h1 className={styles['title-container']}>
                     {t('WEBSITE_SLOGAN_NEW_NEW')}
-                </div>
-                <div className={styles['slogan-container']}>
+                </h1>
+                <p className={styles['slogan-container']}>
                     {t('WEBSITE_SLOGAN_ALL')}
-                </div>
+                </p>
             </div>
-            <div className={styles['content-container']}>
-                <div className={styles['form-container']}>
-                    <CredentialsTextInput
-                        ref={emailRef}
-                        className={styles['credentials-text-input']}
-                        type={'email'}
-                        placeholder={t('EMAIL')}
-                        value={state.email}
-                        onChange={emailOnChange}
-                        onSubmit={emailOnSubmit}
-                    />
-                    <CredentialsTextInput
-                        ref={passwordRef}
-                        className={styles['credentials-text-input']}
-                        type={'password'}
-                        placeholder={t('PASSWORD')}
-                        value={state.password}
-                        onChange={passwordOnChange}
-                        onSubmit={passwordOnSubmit}
-                    />
+            <main className={styles['auth-card']}>
+                <div className={styles['form-tabs']} role={'tablist'} aria-label={`${t('LOG_IN')} / ${t('SIGN_UP')}`}>
+                    <button
+                        id={'auth-login-tab'}
+                        className={classnames(styles['tab-button'], { [styles['active']]: state.form === LOGIN_FORM })}
+                        type={'button'}
+                        role={'tab'}
+                        aria-selected={state.form === LOGIN_FORM}
+                        aria-controls={'auth-form-panel'}
+                        onClick={() => switchForm(LOGIN_FORM)}
+                    >
+                        {t('LOG_IN')}
+                    </button>
+                    <button
+                        id={'auth-signup-tab'}
+                        className={classnames(styles['tab-button'], { [styles['active']]: state.form === SIGNUP_FORM })}
+                        type={'button'}
+                        role={'tab'}
+                        aria-selected={state.form === SIGNUP_FORM}
+                        aria-controls={'auth-form-panel'}
+                        onClick={() => switchForm(SIGNUP_FORM)}
+                    >
+                        {t('SIGN_UP')}
+                    </button>
+                </div>
+                <form
+                    id={'auth-form-panel'}
+                    className={styles['form-container']}
+                    role={'tabpanel'}
+                    aria-labelledby={state.form === SIGNUP_FORM ? 'auth-signup-tab' : 'auth-login-tab'}
+                    noValidate={true}
+                    onSubmit={formOnSubmit}
+                >
+                    <h2 id={'auth-form-title'} className={styles['form-title']}>
+                        {state.form === SIGNUP_FORM ? t('SIGN_UP_EMAIL') : t('LOGIN_LABEL')}
+                    </h2>
+                    <div className={styles['field-container']}>
+                        <label className={styles['field-label']} htmlFor={'auth-email'}>{t('EMAIL')}</label>
+                        <CredentialsTextInput
+                            ref={emailRef}
+                            id={'auth-email'}
+                            name={'email'}
+                            className={styles['credentials-text-input']}
+                            type={'email'}
+                            autoComplete={'email'}
+                            value={state.email}
+                            aria-invalid={state.error.length > 0}
+                            aria-describedby={state.error.length > 0 ? 'auth-error' : undefined}
+                            onChange={emailOnChange}
+                            onSubmit={emailOnSubmit}
+                        />
+                    </div>
+                    <div className={styles['field-container']}>
+                        <label className={styles['field-label']} htmlFor={'auth-password'}>{t('PASSWORD')}</label>
+                        <CredentialsTextInput
+                            ref={passwordRef}
+                            id={'auth-password'}
+                            name={'password'}
+                            className={styles['credentials-text-input']}
+                            type={'password'}
+                            autoComplete={state.form === SIGNUP_FORM ? 'new-password' : 'current-password'}
+                            value={state.password}
+                            aria-invalid={state.error.length > 0}
+                            aria-describedby={state.error.length > 0 ? 'auth-error' : undefined}
+                            onChange={passwordOnChange}
+                            onSubmit={passwordOnSubmit}
+                        />
+                    </div>
                     {
                         state.form === SIGNUP_FORM ?
                             <React.Fragment>
-                                <CredentialsTextInput
-                                    ref={confirmPasswordRef}
-                                    className={styles['credentials-text-input']}
-                                    type={'password'}
-                                    placeholder={t('PASSWORD_CONFIRM')}
-                                    value={state.confirmPassword}
-                                    onChange={confirmPasswordOnChange}
-                                    onSubmit={confirmPasswordOnSubmit}
-                                />
-                                <Checkbox
-                                    ref={termsRef}
-                                    label={t('READ_AND_AGREE')}
-                                    link={t('TOS')}
-                                    href={'https://www.stremio.com/tos'}
-                                    checked={state.termsAccepted}
-                                    onChange={toggleTermsAccepted}
-                                />
-                                <Checkbox
-                                    ref={privacyPolicyRef}
-                                    label={t('READ_AND_AGREE')}
-                                    link={t('PRIVACY_POLICY')}
-                                    href={'https://www.stremio.com/privacy'}
-                                    checked={state.privacyPolicyAccepted}
-                                    onChange={togglePrivacyPolicyAccepted}
-                                />
-                                <Checkbox
-                                    ref={marketingRef}
-                                    label={t('MARKETING_AGREE')}
-                                    checked={state.marketingAccepted}
-                                    onChange={toggleMarketingAccepted}
-                                />
+                                <div className={styles['field-container']}>
+                                    <label className={styles['field-label']} htmlFor={'auth-confirm-password'}>{t('PASSWORD_CONFIRM')}</label>
+                                    <CredentialsTextInput
+                                        ref={confirmPasswordRef}
+                                        id={'auth-confirm-password'}
+                                        name={'confirmPassword'}
+                                        className={styles['credentials-text-input']}
+                                        type={'password'}
+                                        autoComplete={'new-password'}
+                                        value={state.confirmPassword}
+                                        aria-invalid={state.error.length > 0}
+                                        aria-describedby={state.error.length > 0 ? 'auth-error' : undefined}
+                                        onChange={confirmPasswordOnChange}
+                                        onSubmit={confirmPasswordOnSubmit}
+                                    />
+                                </div>
+                                <div className={styles['consent-container']}>
+                                    <Checkbox
+                                        ref={termsRef}
+                                        className={styles['consent-checkbox']}
+                                        name={'termsAccepted'}
+                                        label={t('READ_AND_AGREE')}
+                                        link={t('TOS')}
+                                        href={'https://www.stremio.com/tos'}
+                                        checked={state.termsAccepted}
+                                        onChange={toggleTermsAccepted}
+                                    />
+                                    <Checkbox
+                                        ref={privacyPolicyRef}
+                                        className={styles['consent-checkbox']}
+                                        name={'privacyPolicyAccepted'}
+                                        label={t('READ_AND_AGREE')}
+                                        link={t('PRIVACY_POLICY')}
+                                        href={'https://www.stremio.com/privacy'}
+                                        checked={state.privacyPolicyAccepted}
+                                        onChange={togglePrivacyPolicyAccepted}
+                                    />
+                                    <Checkbox
+                                        ref={marketingRef}
+                                        className={styles['consent-checkbox']}
+                                        name={'marketingAccepted'}
+                                        label={t('MARKETING_AGREE')}
+                                        checked={state.marketingAccepted}
+                                        onChange={toggleMarketingAccepted}
+                                    />
+                                </div>
                             </React.Fragment>
                             :
-                            <div className={styles['forgot-password-link-container']}>
-                                <Button className={styles['forgot-password-link']} onClick={openPasswordRestModal}>{t('FORGOT_PASSWORD')}</Button>
-                            </div>
+                            <button className={styles['forgot-password-link']} type={'button'} onClick={openPasswordRestModal}>
+                                {t('FORGOT_PASSWORD')}
+                            </button>
                     }
                     {
                         state.error && state.error.length > 0 ?
-                            <div ref={errorRef} className={styles['error-message']}>{state.error}</div>
+                            <div id={'auth-error'} ref={errorRef} className={styles['error-message']} role={'alert'} aria-live={'polite'}>{state.error}</div>
                             :
                             null
                     }
-                    <Button className={classnames(styles['form-button'], styles['submit-button'])} onClick={state.form === SIGNUP_FORM ? signup : loginWithEmail}>
-                        <div className={styles['label']}>{state.form === SIGNUP_FORM ? t('SIGN_UP') : t('LOG_IN')}</div>
-                    </Button>
+                    <button className={classnames(styles['form-button'], styles['submit-button'])} type={'submit'}>
+                        {state.form === SIGNUP_FORM ? t('SIGN_UP') : t('LOG_IN')}
+                    </button>
+                </form>
+                <div className={styles['divider']}>
+                    <span>{t('OR')}</span>
                 </div>
-                <div className={styles['options-container']}>
-                    <Button className={classnames(styles['form-button'], styles['facebook-button'])} onClick={loginWithFacebook}>
+                <div className={styles['social-buttons']}>
+                    <button className={classnames(styles['form-button'], styles['facebook-button'])} type={'button'} onClick={loginWithFacebook}>
                         <Icon className={styles['icon']} name={'facebook'} />
-                        <div className={styles['label']}>{t('FB_LOGIN')}</div>
-                    </Button>
-                    <Button className={classnames(styles['form-button'], styles['apple-button'])} onClick={loginWithApple}>
+                        <span>{t('FB_LOGIN')}</span>
+                    </button>
+                    <button className={classnames(styles['form-button'], styles['apple-button'])} type={'button'} onClick={loginWithApple}>
                         <Icon className={styles['icon']} name={'macos'} />
-                        <div className={styles['label']}>{t('APPLE_LOGIN')}</div>
-                    </Button>
-                    {
-                        state.form === SIGNUP_FORM ?
-                            <Button className={classnames(styles['form-button'], styles['login-form-button'])} onClick={switchFormOnClick}>
-                                <div className={styles['label']}>{t('LOG_IN')}</div>
-                            </Button>
-                            :
-                            null
-                    }
-                    {
-                        state.form === LOGIN_FORM ?
-                            <Button className={classnames(styles['form-button'], styles['signup-form-button'])} onClick={switchFormOnClick}>
-                                <div className={styles['label']}>{t('SIGN_UP_EMAIL')}</div>
-                            </Button>
-                            :
-                            null
-                    }
-                    {
-                        state.form === SIGNUP_FORM ?
-                            <Button className={classnames(styles['form-button'], styles['guest-login-button'])} onClick={loginAsGuest}>
-                                <div className={styles['label']}>{t('GUEST_LOGIN')}</div>
-                            </Button>
-                            :
-                            null
-                    }
+                        <span>{t('APPLE_LOGIN')}</span>
+                    </button>
                 </div>
-            </div>
+                {
+                    state.form === SIGNUP_FORM ?
+                        <button className={styles['guest-login-button']} type={'button'} onClick={loginAsGuest}>
+                            {t('GUEST_LOGIN')}
+                        </button>
+                        :
+                        null
+                }
+            </main>
             {
                 passwordRestModalOpen ?
                     <PasswordResetModal email={state.email} onCloseRequest={closePasswordResetModal} />
@@ -422,9 +478,9 @@ const Intro = () => {
                         <div className={styles['loader-container']}>
                             <Icon className={styles['icon']} name={'person'} />
                             <div className={styles['label']}>{t('AUTHENTICATING')}</div>
-                            <Button className={styles['button']} onClick={cancelLoginWithFacebook && cancelLoginWithApple}>
+                            <button className={styles['button']} type={'button'} onClick={cancelAuthentication}>
                                 {t('BUTTON_CANCEL')}
-                            </Button>
+                            </button>
                         </div>
                     </Modal>
                     :

--- a/src/routes/Intro/styles.less
+++ b/src/routes/Intro/styles.less
@@ -1,4 +1,4 @@
-// Copyright (C) 2017-2023 Smart code 203358507
+// Copyright (C) 2017-2026 Smart code 203358507
 
 @import (reference) '~@stremio/stremio-colors/less/stremio-colors.less';
 @import (reference) '~stremio/common/screen-sizes.less';
@@ -9,16 +9,15 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    height: 100%;
+    min-height: 100%;
+    padding: 2rem 1.5rem;
     overflow-y: auto;
+    box-sizing: border-box;
 
     .background-container {
         z-index: -1;
         position: fixed;
-        top: -1rem;
-        bottom: -1rem;
-        left: -1rem;
-        right: -1rem;
+        inset: -1rem;
         background: url('/assets/images/background_1.svg'), url('/assets/images/background_2.svg');
         background-color: var(--primary-background-color);
         background-position: bottom left, top right;
@@ -32,185 +31,261 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        justify-content: center;
-        margin-bottom: 5rem;
+        margin-bottom: 1.5rem;
+        text-align: center;
 
         .logo-container {
             flex: none;
-            margin-bottom: 3rem;
+            margin-bottom: 1rem;
 
             .logo {
-                height: 5rem;
-                opacity: 0.9;
+                display: block;
+                height: 3.5rem;
+                opacity: 0.95;
             }
         }
 
-        .title-container, .slogan-container {
+        .title-container,
+        .slogan-container {
+            margin: 0;
             color: var(--primary-foreground-color);
         }
 
         .title-container {
-            font-size: 3rem;
-            font-weight: 600;
-            margin-bottom: 0.5rem;
+            font-size: 2rem;
+            font-weight: 650;
+            line-height: 1.2;
         }
 
         .slogan-container {
-            font-size: 1.5rem;
-            font-weight: 400;
-            text-transform: lowercase;
-            opacity: 0.6;
-            
-            &::first-letter {
-                text-transform: uppercase;
-            }
+            margin-top: 0.35rem;
+            font-size: 1rem;
+            line-height: 1.4;
+            opacity: 0.65;
         }
     }
 
-    .content-container {
+    .auth-card {
         flex: none;
-        display: flex;
-        flex-direction: row;
-        align-items: flex-start;
-        justify-content: center;
-        width: 100%;
-    
-        .form-button {
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-            justify-content: center;
-            height: 4rem;
-            border-radius: 3.5rem;
-            padding: 0 1rem;
+        width: min(32rem, 100%);
+        padding: 1.75rem;
+        border: 1px solid var(--overlay-color);
+        border-radius: 1.25rem;
+        box-sizing: border-box;
+        color: var(--primary-foreground-color);
+        background-color: var(--modal-background-color);
+        box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.3);
 
-            .icon {
-                flex: none;
-                height: 2rem;
-                width: 2rem;
-                margin-right: 1rem;
-                color: var(--primary-foreground-color);
-            }
-
-            .label {
-                flex-grow: 0;
-                flex-shrink: 1;
-                flex-basis: auto;
-                font-size: 1.1rem;
-                font-weight: 700;
-                color: var(--primary-foreground-color);
-                text-align: center;
-            }
+        button {
+            border: 0;
+            font: inherit;
+            cursor: pointer;
         }
 
-        .submit-button, .guest-login-button, .signup-form-button, .login-form-button {
-            margin-top: 1rem;
-            outline: var(--focus-outline-size) solid var(--primary-foreground-color);
-            background-color: transparent;
+        button:focus-visible,
+        input:focus-visible {
+            outline: var(--focus-outline-size) solid var(--primary-accent-color);
+            outline-offset: 2px;
+        }
 
-            .label {
+        .form-tabs {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 0.25rem;
+            padding: 0.25rem;
+            border-radius: 0.75rem;
+            background-color: var(--overlay-color);
+
+            .tab-button {
+                min-height: 2.75rem;
+                padding: 0.5rem 1rem;
+                border-radius: 0.55rem;
                 color: var(--primary-foreground-color);
-            }
+                background: transparent;
+                font-weight: 600;
+                opacity: 0.65;
+                transition: background-color 0.15s ease-out, opacity 0.15s ease-out;
 
-            &:hover {
-                background-color: var(--primary-foreground-color);
+                &:hover {
+                    opacity: 1;
+                }
 
-                .label {
-                    color: var(--secondary-foreground-color);
+                &.active {
+                    background-color: var(--primary-accent-color);
+                    opacity: 1;
                 }
             }
         }
 
         .form-container {
-            flex: none;
-            position: relative;
-            width: 22rem;
-            margin-right: 2rem;
+            display: flex;
+            flex-direction: column;
 
-            .credentials-text-input {
-                display: block;
-                width: 100%;
+            .form-title {
+                margin: 1.5rem 0 1.25rem;
+                font-size: 1.35rem;
+                font-weight: 650;
+                line-height: 1.25;
+                text-align: center;
+            }
+
+            .field-container {
                 margin-bottom: 1rem;
-                padding: 1rem;
-                border-radius: var(--border-radius);
-                outline-offset: calc(-1 * var(--focus-outline-size));
-                color: var(--primary-foreground-color);
-                background: var(--overlay-color);
 
-                &:hover, &:focus {
-                    outline: var(--focus-outline-size) solid var(--overlay-color);
+                .field-label {
+                    display: block;
+                    margin-bottom: 0.45rem;
+                    font-size: 0.85rem;
+                    font-weight: 600;
+                    opacity: 0.8;
+                }
+
+                .credentials-text-input {
+                    display: block;
+                    width: 100%;
+                    height: 3.25rem;
+                    padding: 0 1rem;
+                    border: 1px solid transparent;
+                    border-radius: 0.7rem;
+                    box-sizing: border-box;
+                    color: var(--primary-foreground-color);
+                    background-color: var(--overlay-color);
+
+                    &:hover {
+                        border-color: var(--primary-foreground-color);
+                    }
+
+                    &:focus {
+                        border-color: var(--primary-accent-color);
+                    }
+
+                    &[aria-invalid='true'] {
+                        border-color: var(--tertiary-accent-color);
+                    }
                 }
             }
 
-            .forgot-password-link-container {
+            .consent-container {
                 display: flex;
-                flex-direction: row;
-                justify-content: flex-end;
-                margin: 1rem 0;
-                text-align: right;
+                flex-direction: column;
+                gap: 0.15rem;
+                margin: 0.1rem 0 0.75rem;
 
-                .forgot-password-link {
-                    flex-grow: 0;
-                    flex-shrink: 1;
-                    flex-basis: auto;
-                    padding: 0.5rem 1rem;
-                    color: var(--primary-foreground-color);
+                .consent-checkbox {
+                    min-height: 2.75rem;
+                }
+            }
 
-                    &:hover {
-                        text-decoration: underline;
-                    }
+            .forgot-password-link {
+                align-self: flex-end;
+                margin: -0.35rem 0 0.85rem;
+                padding: 0.35rem 0;
+                color: var(--primary-accent-color);
+                background: transparent;
+                font-size: 0.9rem;
+
+                &:hover {
+                    text-decoration: underline;
                 }
             }
 
             .error-message {
-                margin: 1rem 0;
-                padding: 0 1rem;
-                text-align: center;
-                color: var(--tertiary-accent-color);
+                margin-bottom: 1rem;
+                padding: 0.75rem 1rem;
+                border-left: 0.2rem solid var(--tertiary-accent-color);
+                border-radius: 0.4rem;
+                color: var(--primary-foreground-color);
+                background-color: var(--overlay-color);
+                font-size: 0.9rem;
+                line-height: 1.4;
             }
         }
 
-        .options-container {
-            flex: none;
-            position: relative;
-            width: 22rem;
-            margin-left: 2rem;
+        .form-button {
             display: flex;
-            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 3.25rem;
+            padding: 0.5rem 1rem;
+            border-radius: 0.7rem;
+            box-sizing: border-box;
+            font-weight: 650;
+            transition: filter 0.15s ease-out, transform 0.15s ease-out;
+
+            &:hover {
+                filter: brightness(1.12);
+            }
+
+            &:active {
+                transform: translateY(1px);
+            }
+
+            .icon {
+                flex: none;
+                width: 1.5rem;
+                height: 1.5rem;
+                margin-right: 0.65rem;
+            }
+        }
+
+        .submit-button {
+            width: 100%;
+            color: var(--primary-foreground-color);
+            background-color: var(--primary-accent-color);
+        }
+
+        .divider {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            margin: 1.25rem 0;
+            color: var(--primary-foreground-color);
+            font-size: 0.75rem;
+            font-weight: 600;
+            opacity: 0.55;
+
+            &::before,
+            &::after {
+                content: '';
+                flex: 1;
+                height: 1px;
+                background-color: var(--primary-foreground-color);
+                opacity: 0.35;
+            }
+        }
+
+        .social-buttons {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 0.75rem;
 
             .facebook-button {
-                background: var(--color-facebook);
-                margin-bottom: 1rem;
-                
-                &:hover, &:focus {
-                    outline: var(--focus-outline-size) solid var(--color-facebook);
-                    background-color: transparent;
-                }
+                color: var(--primary-foreground-color);
+                background-color: var(--color-facebook);
             }
 
             .apple-button {
-                background: var(--primary-foreground-color);
+                color: var(--primary-background-color);
+                background-color: var(--primary-foreground-color);
 
                 .icon {
                     color: var(--primary-background-color);
                 }
+            }
+        }
 
-                .label {
-                    color: var(--primary-background-color);
-                }
-                
-                &:hover, &:focus {
-                    outline: var(--focus-outline-size) solid var(--primary-foreground-color);
-                    background-color: transparent;
+        .guest-login-button {
+            display: block;
+            margin: 1rem auto 0;
+            padding: 0.4rem;
+            color: var(--primary-foreground-color);
+            background: transparent;
+            font-size: 0.9rem;
+            opacity: 0.7;
 
-                    .icon {
-                        color: var(--primary-foreground-color);
-                    }
-
-                    .label {
-                        color: var(--primary-foreground-color);
-                    }
-                }
+            &:hover {
+                text-decoration: underline;
+                opacity: 1;
             }
         }
     }
@@ -234,13 +309,8 @@
         background-color: var(--modal-background-color);
 
         @keyframes flash {
-            0% {
-                opacity: 0.4;
-            }
-
-            100% {
-                opacity: 1.0;
-            }
+            0% { opacity: 0.4; }
+            100% { opacity: 1; }
         }
 
         .icon {
@@ -259,20 +329,24 @@
 
         .button {
             display: flex;
-            flex-direction: row;
             align-items: center;
             justify-content: center;
-            height: 3.5rem;
             width: 100%;
-            border-radius: 3.5rem;
-            padding: 0 1rem;
+            height: 3.5rem;
             margin-top: 2rem;
+            padding: 0 1rem;
+            border: 0;
+            border-radius: 3.5rem;
+            color: var(--primary-foreground-color);
+            background: transparent;
+            font: inherit;
             font-size: 1.1rem;
             font-weight: 700;
-            color: var(--primary-foreground-color);
             outline: var(--focus-outline-size) solid var(--primary-foreground-color);
+            cursor: pointer;
 
-            &:hover {
+            &:hover,
+            &:focus-visible {
                 color: var(--secondary-foreground-color);
                 background-color: var(--primary-foreground-color);
             }
@@ -282,53 +356,61 @@
 
 @media only screen and (max-width: @xsmall) {
     .intro-container {
-        justify-content: initial;
-        padding: 3rem 1.5rem;
+        justify-content: flex-start;
+        padding: 1.25rem 0.75rem;
 
         .heading-container {
-            align-items: flex-start;
-            margin-bottom: 4rem;
+            margin-bottom: 1rem;
 
             .logo-container {
+                margin-bottom: 0.65rem;
+
                 .logo {
-                    height: 4rem;
+                    height: 2.75rem;
                 }
             }
 
             .title-container {
-                font-size: 2.5rem;
+                font-size: 1.6rem;
             }
 
             .slogan-container {
-                font-size: 1.5rem;
+                font-size: 0.9rem;
             }
         }
 
-        .content-container {
-            flex-direction: column-reverse;
+        .auth-card {
+            padding: 1.25rem;
+            border-radius: 1rem;
 
-            .form-container, .options-container {
-                width: 50%;
-                margin: 0 auto;
-            }
-
-            .options-container {
-                margin-bottom: 4rem;
+            .social-buttons {
+                grid-template-columns: 1fr;
             }
         }
     }
 }
 
-@media only screen and (max-width: @minimum) {
+@media only screen and (max-height: 48rem) {
     .intro-container {
-        .content-container {
-            .form-container, .options-container {
-                width: 100%;
-                margin: 0;
+        justify-content: flex-start;
+
+        .heading-container {
+            margin-bottom: 1rem;
+
+            .logo-container {
+                margin-bottom: 0.5rem;
+
+                .logo {
+                    height: 2.75rem;
+                }
             }
 
-            .options-container {
-                margin-bottom: 4rem;
+            .title-container {
+                font-size: 1.6rem;
+            }
+
+            .slogan-container {
+                font-size: 0.9rem;
             }
         }
     }

--- a/tests/checkbox.spec.tsx
+++ b/tests/checkbox.spec.tsx
@@ -1,0 +1,42 @@
+/** @jest-environment jsdom */
+
+// Copyright (C) 2017-2026 Smart code 203358507
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+jest.mock('../src/components/Checkbox/Checkbox.less', () => ({}), { virtual: true });
+jest.mock('stremio/components/Icon', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+jest.mock('../src/components/Button', () => ({
+    __esModule: true,
+    default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}));
+
+import Checkbox from '../src/components/Checkbox/Checkbox';
+
+describe('Checkbox', () => {
+    test('uses one native, labelled checkbox control', () => {
+        const onChange = jest.fn();
+
+        render(
+            <Checkbox
+                name={'termsAccepted'}
+                label={'Read and agree to'}
+                link={'Terms of Service'}
+                href={'https://www.stremio.com/tos'}
+                checked={false}
+                onChange={onChange}
+            />
+        );
+
+        const checkbox = screen.getByRole('checkbox', { name: /Read and agree to Terms of Service/i });
+        expect(screen.getAllByRole('checkbox')).toHaveLength(1);
+        expect(checkbox.getAttribute('name')).toBe('termsAccepted');
+
+        fireEvent.click(checkbox);
+        expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ checked: true }));
+    });
+});

--- a/tests/intro.spec.js
+++ b/tests/intro.spec.js
@@ -1,0 +1,189 @@
+/** @jest-environment jsdom */
+
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const React = require('react');
+const { describe, expect, jest, beforeEach, test } = require('@jest/globals');
+const { act, fireEvent, render, screen } = require('@testing-library/react');
+const { MemoryRouter } = require('react-router-dom');
+
+const mockDispatch = jest.fn();
+const mockCoreHandlers = new Map();
+const mockStartFacebookLogin = jest.fn();
+const mockStopFacebookLogin = jest.fn();
+const mockStartAppleLogin = jest.fn();
+const mockStopAppleLogin = jest.fn();
+const mockCore = {
+    transport: { dispatch: mockDispatch },
+    on: jest.fn((name, handler) => mockCoreHandlers.set(name, handler)),
+    off: jest.fn((name) => mockCoreHandlers.delete(name)),
+};
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock('stremio/core', () => ({
+    useCore: () => mockCore,
+}));
+
+jest.mock('stremio/common', () => {
+    const React = require('react');
+
+    return {
+        useBinaryState: (initialValue) => {
+            const [value, setValue] = React.useState(initialValue);
+            return [value, () => setValue(true), () => setValue(false)];
+        },
+    };
+});
+
+jest.mock('stremio/common/useRouteFocused', () => ({
+    default: () => true,
+}));
+
+jest.mock('stremio/components/Icon', () => ({
+    default: () => null,
+}));
+
+jest.mock('stremio/components', () => {
+    const React = require('react');
+    const PropTypes = require('prop-types');
+    const Image = (props) => React.createElement('img', props);
+    const Checkbox = React.forwardRef(({ name, label, link, href, checked, onChange }, ref) => (
+        React.createElement('label', null,
+            React.createElement('input', {
+                ref,
+                type: 'checkbox',
+                id: name,
+                name,
+                checked,
+                onChange,
+            }),
+            label,
+            href && link ? React.createElement('a', { href }, link) : null
+        )
+    ));
+    const TextInput = React.forwardRef(({ onSubmit, onKeyDown, ...props }, ref) => (
+        React.createElement('input', {
+            ...props,
+            ref,
+            onKeyDown: (event) => {
+                onKeyDown && onKeyDown(event);
+                if (event.key === 'Enter') onSubmit && onSubmit(event);
+            },
+        })
+    ));
+
+    Image.propTypes = { alt: PropTypes.string };
+    Checkbox.propTypes = {
+        name: PropTypes.string,
+        label: PropTypes.string,
+        link: PropTypes.string,
+        href: PropTypes.string,
+        checked: PropTypes.bool,
+        onChange: PropTypes.func,
+    };
+    TextInput.propTypes = {
+        onSubmit: PropTypes.func,
+        onKeyDown: PropTypes.func,
+    };
+
+    return { Image, Checkbox, TextInput };
+});
+
+jest.mock('stremio/router/Modal', () => {
+    const React = require('react');
+    const PropTypes = require('prop-types');
+    const Modal = ({ children }) => React.createElement('div', null, children);
+    Modal.propTypes = { children: PropTypes.node };
+    return Modal;
+});
+
+jest.mock('../src/routes/Intro/PasswordResetModal', () => () => null);
+jest.mock('../src/routes/Intro/useFacebookLogin', () => () => [mockStartFacebookLogin, mockStopFacebookLogin]);
+jest.mock('../src/routes/Intro/useAppleLogin', () => ({
+    __esModule: true,
+    default: () => [mockStartAppleLogin, mockStopAppleLogin],
+}));
+jest.mock('../src/routes/Intro/styles', () => ({}), { virtual: true });
+jest.mock('/assets/images/logo.png', () => 'logo.png', { virtual: true });
+
+const Intro = require('../src/routes/Intro/Intro');
+
+const renderIntro = (form = 'login') => render(
+    React.createElement(
+        MemoryRouter,
+        {
+            initialEntries: [`/intro?form=${form}`],
+            future: { v7_startTransition: true, v7_relativeSplatPath: true },
+        },
+        React.createElement(Intro)
+    )
+);
+
+describe('Intro authentication', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockCoreHandlers.clear();
+        mockStartFacebookLogin.mockImplementation(() => new Promise(() => {}));
+        mockStartAppleLogin.mockImplementation(() => new Promise(() => {}));
+        Element.prototype.scrollIntoView = jest.fn();
+    });
+
+    test('exposes a labelled login form with native controls', () => {
+        renderIntro();
+
+        expect(screen.getByRole('tab', { name: 'LOG_IN' }).getAttribute('aria-selected')).toBe('true');
+        expect(screen.getByRole('textbox', { name: 'EMAIL' }).getAttribute('autocomplete')).toBe('email');
+        expect(screen.getByLabelText('PASSWORD').getAttribute('autocomplete')).toBe('current-password');
+        expect(screen.getByRole('button', { name: 'LOG_IN' }).getAttribute('type')).toBe('submit');
+        expect(screen.getByRole('button', { name: 'FORGOT_PASSWORD' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'FB_LOGIN' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'APPLE_LOGIN' })).toBeTruthy();
+    });
+
+    test('keeps the email when switching to registration', () => {
+        renderIntro();
+
+        fireEvent.change(screen.getByRole('textbox', { name: 'EMAIL' }), {
+            target: { value: 'viewer@example.com' },
+        });
+        fireEvent.click(screen.getByRole('tab', { name: 'SIGN_UP' }));
+
+        expect(screen.getByRole('textbox', { name: 'EMAIL' }).value).toBe('viewer@example.com');
+        expect(screen.getByLabelText('PASSWORD_CONFIRM').getAttribute('autocomplete')).toBe('new-password');
+        expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+        expect(screen.getByRole('button', { name: 'GUEST_LOGIN' })).toBeTruthy();
+    });
+
+    test('shows validation and authentication errors in the form', () => {
+        renderIntro();
+
+        fireEvent.click(screen.getByRole('button', { name: 'LOG_IN' }));
+        expect(screen.getByRole('alert').textContent).toBe('INVALID_EMAIL');
+        expect(mockDispatch).not.toHaveBeenCalled();
+
+        fireEvent.change(screen.getByRole('textbox', { name: 'EMAIL' }), {
+            target: { value: 'viewer@example.com' },
+        });
+        fireEvent.change(screen.getByLabelText('PASSWORD'), {
+            target: { value: 'secret' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'LOG_IN' }));
+
+        expect(mockDispatch).toHaveBeenCalledTimes(1);
+        act(() => mockCoreHandlers.get('error')({ event: 'UserAuthenticated' }));
+        expect(screen.getByRole('alert').textContent).toBe('LOGIN_FAILED');
+    });
+
+    test('cancels both social authentication providers', () => {
+        renderIntro();
+
+        fireEvent.click(screen.getByRole('button', { name: 'FB_LOGIN' }));
+        fireEvent.click(screen.getByRole('button', { name: 'BUTTON_CANCEL' }));
+
+        expect(mockStopFacebookLogin).toHaveBeenCalledTimes(1);
+        expect(mockStopAppleLogin).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Summary

- replace the split login/register layout with a single focused authentication card
- add clear login and registration tabs, persistent labels, autocomplete hints, and native form semantics
- improve consent controls, keyboard accessibility, responsive layout, and authentication error feedback
- fix cancellation so both Apple and Facebook authentication flows are stopped
- preserve the entered email when switching between login and registration

## User impact

The authentication flow now has a clear primary action and keeps email, social login, guest access, consent, and recovery options in a predictable hierarchy. Errors are announced and displayed instead of silently closing the loader.

## Validation

- `eslint src`
- 114 Jest tests
- production webpack build
- visual verification of login and registration in the release UI

Closes #61