### PR TITLE
feat(router): add resilient route loading states

### DIFF
--- a/src/components/RouteLoading/RouteLoading.js
+++ b/src/components/RouteLoading/RouteLoading.js
@@ -1,0 +1,164 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const React = require('react');
+const PropTypes = require('prop-types');
+const { useTranslation } = require('react-i18next');
+const { default: Button } = require('stremio/components/Button');
+const { default: MainNavBars } = require('stremio/components/MainNavBars');
+const styles = require('./RouteLoading.less');
+
+const getLoadingPresentation = (pathname = '/') => {
+    if (pathname.startsWith('/intro')) return { kind: 'auth', route: null };
+    if (pathname.startsWith('/player')) return { kind: 'player', route: null };
+    if (pathname.startsWith('/discover')) return { kind: 'grid', route: 'discover' };
+    if (pathname.startsWith('/library')) return { kind: 'grid', route: 'library' };
+    if (pathname.startsWith('/continuewatching')) return { kind: 'grid', route: 'continue_watching' };
+    if (pathname.startsWith('/calendar')) return { kind: 'calendar', route: 'calendar' };
+    if (pathname.startsWith('/addons')) return { kind: 'addons', route: 'addons' };
+    if (pathname.startsWith('/settings')) return { kind: 'settings', route: 'settings' };
+    if (pathname.startsWith('/search')) return { kind: 'rows', route: 'search' };
+    if (pathname.startsWith('/metadetails') || pathname.startsWith('/detail')) return { kind: 'details', route: 'metadetails' };
+    return { kind: 'board', route: 'board' };
+};
+
+const Skeleton = ({ kind }) => {
+    switch (kind) {
+        case 'auth':
+            return (
+                <div className={styles['auth-skeleton']}>
+                    <div className={styles['brand-mark']} />
+                    <div className={styles['wide-line']} />
+                    <div className={styles['field']} />
+                    <div className={styles['field']} />
+                    <div className={styles['primary-button']} />
+                </div>
+            );
+        case 'player':
+            return <div className={styles['player-spinner']} />;
+        case 'calendar':
+            return (
+                <div className={styles['calendar-skeleton']}>
+                    <div className={styles['toolbar']} />
+                    <div className={styles['calendar-grid']}>
+                        {Array.from({ length: 35 }).map((_, index) => <div key={index} className={styles['calendar-cell']} />)}
+                    </div>
+                </div>
+            );
+        case 'addons':
+            return (
+                <div className={styles['addons-skeleton']}>
+                    <div className={styles['controls']}>
+                        <div /><div /><span /><div />
+                    </div>
+                    {Array.from({ length: 4 }).map((_, index) => (
+                        <div key={index} className={styles['addon-row']}>
+                            <div className={styles['addon-logo']} />
+                            <div className={styles['addon-copy']}><div /><div /><div /></div>
+                            <div className={styles['addon-actions']}><div /><div /></div>
+                        </div>
+                    ))}
+                </div>
+            );
+        case 'settings':
+            return (
+                <div className={styles['settings-skeleton']}>
+                    <div className={styles['settings-menu']}>{Array.from({ length: 6 }).map((_, index) => <div key={index} />)}</div>
+                    <div className={styles['settings-sections']}>{Array.from({ length: 4 }).map((_, index) => <div key={index} />)}</div>
+                </div>
+            );
+        case 'details':
+            return (
+                <div className={styles['details-skeleton']}>
+                    <div className={styles['details-poster']} />
+                    <div className={styles['details-copy']}><div /><div /><div /><div /></div>
+                </div>
+            );
+        case 'rows':
+            return (
+                <div className={styles['rows-skeleton']}>
+                    {Array.from({ length: 3 }).map((_, rowIndex) => (
+                        <div key={rowIndex} className={styles['skeleton-row']}>
+                            <div className={styles['row-title']} />
+                            <div className={styles['posters']}>{Array.from({ length: 7 }).map((_, index) => <div key={index} />)}</div>
+                        </div>
+                    ))}
+                </div>
+            );
+        case 'grid':
+            return (
+                <div className={styles['grid-skeleton']}>
+                    <div className={styles['controls']}><div /><div /><div /></div>
+                    <div className={styles['poster-grid']}>{Array.from({ length: 24 }).map((_, index) => <div key={index} />)}</div>
+                </div>
+            );
+        default:
+            return (
+                <div className={styles['board-skeleton']}>
+                    <div className={styles['hero']} />
+                    <div className={styles['row-title']} />
+                    <div className={styles['posters']}>{Array.from({ length: 7 }).map((_, index) => <div key={index} />)}</div>
+                </div>
+            );
+    }
+};
+
+Skeleton.propTypes = {
+    kind: PropTypes.string.isRequired,
+};
+
+const RouteLoadingContent = ({ kind, error, onRetry, onHome }) => {
+    const { t } = useTranslation();
+
+    return (
+        <div
+            className={styles['loading-content']}
+            role={error ? 'alert' : 'status'}
+            aria-live={'polite'}
+            aria-busy={!error}
+        >
+            {
+                error ?
+                    <div className={styles['error-card']}>
+                        <div className={styles['error-title']}>{t('GENERIC_ERROR_MESSAGE')}</div>
+                        <div className={styles['error-actions']}>
+                            <Button className={styles['retry-button']} onClick={onRetry}>{t('TRY_AGAIN')}</Button>
+                            <Button className={styles['home-button']} onClick={onHome}>{t('WEBSITE_GO_HOME')}</Button>
+                        </div>
+                    </div>
+                    :
+                    <>
+                        <span className={styles['visually-hidden']}>{t('STREAM_LOADING')}</span>
+                        <Skeleton kind={kind} />
+                    </>
+            }
+        </div>
+    );
+};
+
+RouteLoadingContent.propTypes = {
+    kind: PropTypes.string.isRequired,
+    error: PropTypes.bool,
+    onRetry: PropTypes.func,
+    onHome: PropTypes.func,
+};
+
+const RouteLoading = ({ pathname, error, onRetry, onHome }) => {
+    const { kind, route } = getLoadingPresentation(pathname);
+    const content = <RouteLoadingContent kind={kind} error={error} onRetry={onRetry} onHome={onHome} />;
+
+    return route === null ?
+        <div className={styles['standalone-shell']}>{content}</div>
+        :
+        <MainNavBars className={styles['navigation-shell']} route={route} overlay={route === 'board'}>
+            {content}
+        </MainNavBars>;
+};
+
+RouteLoading.propTypes = {
+    pathname: PropTypes.string.isRequired,
+    error: PropTypes.bool,
+    onRetry: PropTypes.func,
+    onHome: PropTypes.func,
+};
+
+module.exports = { RouteLoading, RouteLoadingContent, getLoadingPresentation };

--- a/src/components/RouteLoading/RouteLoading.less
+++ b/src/components/RouteLoading/RouteLoading.less
@@ -1,0 +1,354 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+@import (reference) '~stremio/common/screen-sizes.less';
+
+@placeholder: rgba(255, 255, 255, 0.09);
+@placeholder-strong: rgba(255, 255, 255, 0.13);
+
+.pulse() {
+    animation: route-loading-pulse 1.6s ease-in-out infinite;
+}
+
+.block(@radius: var(--border-radius)) {
+    border-radius: @radius;
+    background-color: @placeholder;
+    .pulse();
+}
+
+.navigation-shell, .standalone-shell {
+    width: 100%;
+    height: calc(100% - var(--safe-area-inset-bottom));
+}
+
+.standalone-shell {
+    height: 100%;
+}
+
+.loading-content {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    color: var(--primary-foreground-color);
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.controls {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    height: 5rem;
+
+    > div {
+        width: 12rem;
+        height: 2.75rem;
+        .block();
+    }
+}
+
+.grid-skeleton {
+    height: 100%;
+    padding: 0 var(--content-padding);
+
+    .poster-grid {
+        display: grid;
+        grid-template-columns: repeat(10, minmax(0, 1fr));
+        gap: 1.5rem 0.5rem;
+
+        > div {
+            aspect-ratio: var(--poster-shape-ratio);
+            .block();
+        }
+    }
+}
+
+.board-skeleton, .rows-skeleton {
+    height: 100%;
+    padding: var(--content-padding);
+
+    .hero {
+        width: 100%;
+        height: min(48vh, 31rem);
+        margin-bottom: 2rem;
+        .block(1rem);
+    }
+}
+
+.row-title {
+    width: 11rem;
+    height: 1.4rem;
+    margin-bottom: 1rem;
+    .block();
+}
+
+.posters {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 1rem;
+
+    > div {
+        aspect-ratio: var(--poster-shape-ratio);
+        .block();
+    }
+}
+
+.rows-skeleton {
+    overflow: hidden;
+
+    .skeleton-row {
+        margin-bottom: 2rem;
+    }
+}
+
+.calendar-skeleton {
+    height: 100%;
+    padding: 1.5rem;
+
+    .toolbar {
+        width: 18rem;
+        height: 3rem;
+        margin-bottom: 1rem;
+        .block();
+    }
+
+    .calendar-grid {
+        display: grid;
+        grid-template-columns: repeat(7, minmax(0, 1fr));
+        height: calc(100% - 4rem);
+        gap: 0.5rem;
+
+        .calendar-cell {
+            min-height: 4rem;
+            .block();
+        }
+    }
+}
+
+.addons-skeleton {
+    height: 100%;
+    padding: 0 var(--content-padding) var(--content-padding);
+    overflow: hidden;
+
+    .controls {
+        > span {
+            flex: 1;
+        }
+    }
+
+    .addon-row {
+        display: flex;
+        align-items: center;
+        gap: 1.5rem;
+        min-height: 10rem;
+        margin-bottom: 1rem;
+        padding: 1.5rem;
+        border-radius: var(--border-radius);
+        background-color: rgba(255, 255, 255, 0.04);
+
+        .addon-logo {
+            flex: none;
+            width: 7rem;
+            height: 7rem;
+            .block(50%);
+        }
+
+        .addon-copy {
+            flex: 1;
+
+            > div {
+                width: 75%;
+                height: 1rem;
+                margin-bottom: 0.75rem;
+                .block();
+
+                &:first-child { width: 35%; }
+                &:last-child { width: 55%; }
+            }
+        }
+
+        .addon-actions {
+            width: 14rem;
+
+            > div {
+                height: 3rem;
+                margin-bottom: 0.75rem;
+                .block();
+            }
+        }
+    }
+}
+
+.settings-skeleton {
+    display: flex;
+    height: 100%;
+    max-width: 64rem;
+    margin: 0 auto;
+    padding: 2rem;
+    gap: 3rem;
+
+    .settings-menu {
+        width: 14rem;
+
+        > div {
+            width: 80%;
+            height: 1.25rem;
+            margin-bottom: 2rem;
+            .block();
+        }
+    }
+
+    .settings-sections {
+        flex: 1;
+
+        > div {
+            height: 8rem;
+            margin-bottom: 1.5rem;
+            .block();
+        }
+    }
+}
+
+.details-skeleton {
+    display: flex;
+    align-items: flex-end;
+    gap: 2rem;
+    height: 100%;
+    padding: 5rem var(--content-padding) var(--content-padding);
+
+    .details-poster {
+        width: min(28vw, 20rem);
+        aspect-ratio: var(--poster-shape-ratio);
+        .block(1rem);
+    }
+
+    .details-copy {
+        flex: 1;
+        padding-bottom: 2rem;
+
+        > div {
+            width: 75%;
+            height: 1.25rem;
+            margin-bottom: 1rem;
+            .block();
+
+            &:first-child { width: 45%; height: 2.5rem; }
+            &:last-child { width: 30%; height: 3.5rem; }
+        }
+    }
+}
+
+.auth-skeleton {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: min(28rem, calc(100% - 3rem));
+    padding: 3rem;
+    transform: translate(-50%, -50%);
+    border-radius: 1.5rem;
+    background-color: rgba(255, 255, 255, 0.04);
+
+    .brand-mark {
+        width: 4rem;
+        height: 4rem;
+        margin-bottom: 2rem;
+        .block(50%);
+    }
+
+    .wide-line, .field, .primary-button {
+        width: 100%;
+        height: 1.5rem;
+        margin-bottom: 1.5rem;
+        .block();
+    }
+
+    .wide-line { width: 60%; }
+    .field { height: 3.5rem; }
+    .primary-button { height: 3.75rem; margin: 0; }
+}
+
+.player-spinner {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 3.5rem;
+    height: 3.5rem;
+    transform: translate(-50%, -50%);
+    border: 0.3rem solid @placeholder;
+    border-top-color: var(--primary-accent-color);
+    border-radius: 50%;
+    animation: route-loading-spin 0.9s linear infinite;
+}
+
+.error-card {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: min(28rem, calc(100% - 3rem));
+    padding: 2.5rem;
+    transform: translate(-50%, -50%);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 1rem;
+    background-color: rgba(20, 18, 29, 0.96);
+    box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.35);
+
+    .error-title {
+        margin-bottom: 2rem;
+        font-size: 1.5rem;
+        text-align: center;
+    }
+
+    .error-actions {
+        display: flex;
+        gap: 1rem;
+
+        .retry-button, .home-button {
+            min-width: 9rem;
+            padding: 1rem 1.5rem;
+            border-radius: var(--border-radius);
+            text-align: center;
+        }
+
+        .retry-button { background-color: var(--primary-accent-color); }
+        .home-button { background-color: var(--overlay-color); }
+    }
+}
+
+@keyframes route-loading-pulse {
+    0%, 100% { opacity: 0.55; }
+    50% { opacity: 1; background-color: @placeholder-strong; }
+}
+
+@keyframes route-loading-spin {
+    to { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+@media only screen and (max-width: @medium) {
+    .grid-skeleton .poster-grid { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+    .posters { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+}
+
+@media only screen and (max-width: @minimum) {
+    .grid-skeleton .poster-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .posters { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .controls > div { width: 8rem; }
+    .addon-actions, .settings-menu { display: none; }
+    .settings-skeleton { padding: 1rem; }
+    .details-skeleton { align-items: center; padding: 2rem; }
+    .details-poster { display: none; }
+}

--- a/src/components/RouteLoading/index.js
+++ b/src/components/RouteLoading/index.js
@@ -1,0 +1,3 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+module.exports = require('./RouteLoading');

--- a/src/router/Route/Route.js
+++ b/src/router/Route/Route.js
@@ -4,16 +4,21 @@ const React = require('react');
 const PropTypes = require('prop-types');
 const { ModalsContainerProvider } = require('../ModalsContainerContext');
 const { RouteFocusedProvider } = require('stremio/common/useRouteFocused');
+const { RouteLoading } = require('stremio/components/RouteLoading');
+const { RouteErrorBoundary, RouteReady } = require('./RouteErrorBoundary');
 
-const Route = ({ component, focused }) => {
+const Route = ({ component, focused, pathname }) => {
     return (
         <div className={'route-container'}>
             <RouteFocusedProvider value={focused}>
                 <ModalsContainerProvider>
                     <div className={'route-content'}>
-                        <React.Suspense fallback={null}>
-                            {component}
-                        </React.Suspense>
+                        <RouteErrorBoundary key={pathname} pathname={pathname}>
+                            <React.Suspense fallback={<RouteLoading pathname={pathname} />}>
+                                {component}
+                                <RouteReady pathname={pathname} />
+                            </React.Suspense>
+                        </RouteErrorBoundary>
                     </div>
                 </ModalsContainerProvider>
             </RouteFocusedProvider>
@@ -24,6 +29,7 @@ const Route = ({ component, focused }) => {
 Route.propTypes = {
     component: PropTypes.node,
     focused: PropTypes.bool,
+    pathname: PropTypes.string.isRequired,
 };
 
 module.exports = Route;

--- a/src/router/Route/RouteErrorBoundary.js
+++ b/src/router/Route/RouteErrorBoundary.js
@@ -1,0 +1,97 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const React = require('react');
+const PropTypes = require('prop-types');
+const { RouteLoading } = require('stremio/components/RouteLoading');
+
+const CHUNK_RELOAD_PREFIX = 'stremio:route-chunk-reload:';
+
+const isChunkLoadError = (error) => {
+    const name = typeof error?.name === 'string' ? error.name : '';
+    const message = typeof error?.message === 'string' ? error.message : '';
+
+    return name === 'ChunkLoadError' ||
+        /Loading chunk [\d]+ failed/i.test(message) ||
+        /Failed to fetch dynamically imported module/i.test(message) ||
+        /Importing a module script failed/i.test(message);
+};
+
+const getReloadKey = (pathname) => `${CHUNK_RELOAD_PREFIX}${pathname}`;
+
+const clearReloadAttempt = (pathname) => {
+    try {
+        window.sessionStorage.removeItem(getReloadKey(pathname));
+    } catch {
+        // Storage can be unavailable in privacy-focused browser contexts.
+    }
+};
+
+const RouteReady = ({ pathname }) => {
+    React.useEffect(() => clearReloadAttempt(pathname), [pathname]);
+    return null;
+};
+
+RouteReady.propTypes = {
+    pathname: PropTypes.string.isRequired,
+};
+
+class RouteErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { error: null };
+        this.retry = this.retry.bind(this);
+        this.goHome = this.goHome.bind(this);
+    }
+
+    static getDerivedStateFromError(error) {
+        return { error };
+    }
+
+    componentDidCatch(error) {
+        if (!isChunkLoadError(error) || process.env.NODE_ENV === 'test') {
+            return;
+        }
+
+        try {
+            const reloadKey = getReloadKey(this.props.pathname);
+            if (window.sessionStorage.getItem(reloadKey) === null) {
+                window.sessionStorage.setItem(reloadKey, '1');
+                window.location.reload();
+            }
+        } catch {
+            // The visible recovery state remains available when storage or reload fails.
+        }
+    }
+
+    retry() {
+        clearReloadAttempt(this.props.pathname);
+        window.location.reload();
+    }
+
+    goHome() {
+        clearReloadAttempt(this.props.pathname);
+        window.location.hash = '#/';
+    }
+
+    render() {
+        if (this.state.error !== null) {
+            return (
+                <RouteLoading
+                    pathname={this.props.pathname}
+                    error={true}
+                    onRetry={this.retry}
+                    onHome={this.goHome}
+                />
+            );
+        }
+
+        return this.props.children;
+    }
+}
+
+RouteErrorBoundary.propTypes = {
+    pathname: PropTypes.string.isRequired,
+    children: PropTypes.node,
+};
+
+module.exports = { RouteErrorBoundary, RouteReady, isChunkLoadError };

--- a/src/router/Routes.tsx
+++ b/src/router/Routes.tsx
@@ -80,7 +80,7 @@ const Routes = () => {
                     <RRoutes key={view.key} location={view.location}>
                         <RRoute
                             path={view.route.path}
-                            element={<Route component={view.route.element} focused={index === visibleViews.length - 1} />}
+                            element={<Route component={view.route.element} focused={index === visibleViews.length - 1} pathname={view.location.pathname} />}
                         />
                     </RRoutes>
                 ))

--- a/src/routes/Addons/Addons.js
+++ b/src/routes/Addons/Addons.js
@@ -9,6 +9,7 @@ const { default: Icon } = require('stremio/components/Icon');
 const { useCore } = require('stremio/core');
 const { usePlatform, useBinaryState, withCoreSuspender } = require('stremio/common');
 const { AddonDetailsModal, Button, Image, MainNavBars, ModalDialog, SearchBar, SharePrompt, TextInput, MultiselectMenu } = require('stremio/components');
+const { RouteLoading } = require('stremio/components/RouteLoading');
 const { default: useToast } = require('stremio/common/Toast/useToast');
 const Addon = require('./Addon');
 const useInstalledAddons = require('./useInstalledAddons');
@@ -312,8 +313,6 @@ const Addons = () => {
     );
 };
 
-const AddonsFallback = () => (
-    <MainNavBars className={styles['addons-container']} route={'addons'} />
-);
+const AddonsFallback = () => <RouteLoading pathname={'/addons'} />;
 
 module.exports = withCoreSuspender(Addons, AddonsFallback);

--- a/src/routes/Board/Board.js
+++ b/src/routes/Board/Board.js
@@ -6,6 +6,7 @@ const debounce = require('lodash.debounce');
 const { default: useTranslate } = require('stremio/common/useTranslate');
 const { useStreamingServer, useNotifications, withCoreSuspender, getVisibleChildrenRange, useProfile } = require('stremio/common');
 const { ContinueWatchingItem, EventModal, HeroBanner, MainNavBars, MetaItem, MetaRow } = require('stremio/components');
+const { RouteLoading } = require('stremio/components/RouteLoading');
 const useBoard = require('./useBoard');
 const useContinueWatchingPreview = require('./useContinueWatchingPreview');
 const styles = require('./styles');
@@ -125,10 +126,6 @@ const Board = () => {
     );
 };
 
-const BoardFallback = () => (
-    <div className={styles['board-container']}>
-        <MainNavBars className={styles['board-content-container']} route={'board'} />
-    </div>
-);
+const BoardFallback = () => <RouteLoading pathname={'/'} />;
 
 module.exports = withCoreSuspender(Board, BoardFallback);

--- a/src/routes/Calendar/Calendar.tsx
+++ b/src/routes/Calendar/Calendar.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 import { useProfile, withCoreSuspender } from 'stremio/common';
 import { MainNavBars, BottomSheet } from 'stremio/components';
+import { RouteLoading } from 'stremio/components/RouteLoading';
 import Selector from './Selector';
 import Table from './Table';
 import List from './List';
@@ -72,8 +73,6 @@ const Calendar = () => {
     );
 };
 
-const CalendarFallback = () => (
-    <MainNavBars className={styles['calendar']} />
-);
+const CalendarFallback = () => <RouteLoading pathname={'/calendar'} />;
 
 export default withCoreSuspender(Calendar, CalendarFallback);

--- a/src/routes/Discover/Discover.js
+++ b/src/routes/Discover/Discover.js
@@ -9,6 +9,7 @@ const { default: Icon } = require('stremio/components/Icon');
 const { useCore } = require('stremio/core');
 const { CONSTANTS, useBinaryState, useOnScrollToBottom, withCoreSuspender } = require('stremio/common');
 const { AddonDetailsModal, Button, DelayedRenderer, Image, MainNavBars, MetaItem, MetaPreview, ModalDialog, MultiselectMenu } = require('stremio/components');
+const { RouteLoading } = require('stremio/components/RouteLoading');
 const useDiscover = require('./useDiscover');
 const useSelectableInputs = require('./useSelectableInputs');
 const styles = require('./styles');
@@ -264,8 +265,6 @@ const Discover = () => {
     );
 };
 
-const DiscoverFallback = () => (
-    <MainNavBars className={styles['discover-container']} route={'discover'} />
-);
+const DiscoverFallback = () => <RouteLoading pathname={'/discover'} />;
 
 module.exports = withCoreSuspender(Discover, DiscoverFallback);

--- a/src/routes/Library/Library.js
+++ b/src/routes/Library/Library.js
@@ -10,6 +10,7 @@ const NotFound = require('stremio/routes/NotFound');
 const { useProfile, useNotifications, useOnScrollToBottom, withCoreSuspender } = require('stremio/common');
 const { default: toPath } = require('stremio-router/toPath');
 const { DelayedRenderer, Chips, Image, MainNavBars, LibItem, MultiselectMenu } = require('stremio/components');
+const { RouteLoading } = require('stremio/components/RouteLoading');
 const { default: Placeholder } = require('./Placeholder');
 const useLibrary = require('./useLibrary');
 const useSelectableInputs = require('./useSelectableInputs');
@@ -128,9 +129,7 @@ Library.propTypes = {
     model: PropTypes.oneOf(['library', 'continue_watching']),
 };
 
-const LibraryFallback = ({ model }) => (
-    <MainNavBars className={styles['library-container']} route={model} />
-);
+const LibraryFallback = ({ model }) => <RouteLoading pathname={model === 'continue_watching' ? '/continuewatching' : '/library'} />;
 
 LibraryFallback.propTypes = Library.propTypes;
 

--- a/src/routes/MetaDetails/MetaDetails.js
+++ b/src/routes/MetaDetails/MetaDetails.js
@@ -7,7 +7,8 @@ const { default: Image } = require('stremio/components/Image');
 const { default: MainNavBars } = require('stremio/components/MainNavBars');
 const ModalDialog = require('stremio/components/ModalDialog');
 const SharePrompt = require('stremio/components/SharePrompt');
-const { DelayedRenderer, HorizontalNavBar } = require('stremio/components');
+const { DelayedRenderer } = require('stremio/components');
+const { RouteLoading } = require('stremio/components/RouteLoading');
 const { useCore } = require('stremio/core');
 const { useContentGamepadNavigation } = require('stremio/services/GamepadNavigation');
 const { withCoreSuspender } = require('stremio/common');
@@ -239,11 +240,7 @@ const MetaDetails = () => {
     }
 
     if (metaItem.content.type === 'Loading') {
-        return (
-            <MainNavBars className={styles['metadetails-container']} route={'metadetails'} overlay>
-                <div className={styles['loading-container']} />
-            </MainNavBars>
-        );
+        return <RouteLoading pathname={'/metadetails'} />;
     }
 
     return (
@@ -411,14 +408,6 @@ const MetaDetails = () => {
     );
 };
 
-const MetaDetailsFallback = () => (
-    <div className={styles['metadetails-container']}>
-        <HorizontalNavBar
-            className={styles['nav-bar']}
-            backButton={true}
-            navMenu={true}
-        />
-    </div>
-);
+const MetaDetailsFallback = () => <RouteLoading pathname={'/metadetails'} />;
 
 module.exports = withCoreSuspender(MetaDetails, MetaDetailsFallback);

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -14,6 +14,7 @@ const { useContentGamepadNavigation } = require('stremio/services/GamepadNavigat
 const { useSettings, useProfile, useFullscreen, useBinaryState, useToast, useStreamingServer, withCoreSuspender, usePlatform, onShortcut, getKeyboardShortcutKey, getKeyboardShortcutKeys, useDiscord, EMPTY_DISCORD_TIMESTAMPS, getPlaybackDiscordActivity } = require('stremio/common');
 const { default: toPath } = require('stremio-router/toPath');
 const { HorizontalNavBar, Transition, ContextMenu } = require('stremio/components');
+const { RouteLoading } = require('stremio/components/RouteLoading');
 const { default: Buffering } = require('./Buffering');
 const VolumeChangeIndicator = require('./VolumeChangeIndicator');
 const Error = require('./Error');
@@ -1175,8 +1176,6 @@ const Player = () => {
     );
 };
 
-const PlayerFallback = () => (
-    <div className={classnames(styles['player-container'])} />
-);
+const PlayerFallback = () => <RouteLoading pathname={'/player'} />;
 
 module.exports = withCoreSuspender(Player, PlayerFallback);

--- a/src/routes/Search/Search.js
+++ b/src/routes/Search/Search.js
@@ -7,6 +7,7 @@ const { default: useTranslate } = require('stremio/common/useTranslate');
 const { default: Icon } = require('stremio/components/Icon');
 const { withCoreSuspender, getVisibleChildrenRange } = require('stremio/common');
 const { Image, MainNavBars, MetaItem, MetaRow } = require('stremio/components');
+const { RouteLoading } = require('stremio/components/RouteLoading');
 const useSearch = require('./useSearch');
 const styles = require('./styles');
 const { useSearchParams } = require('react-router-dom');
@@ -128,9 +129,6 @@ const Search = () => {
     );
 };
 
-const SearchFallback = () => {
-    const [queryParams] = useSearchParams();
-    return <MainNavBars className={styles['search-container']} route={'search'} query={queryParams.get('search') ?? queryParams.get('query')} />;
-};
+const SearchFallback = () => <RouteLoading pathname={'/search'} />;
 
 module.exports = withCoreSuspender(Search, SearchFallback);

--- a/src/routes/Settings/Settings.tsx
+++ b/src/routes/Settings/Settings.tsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import throttle from 'lodash.throttle';
 import { usePlatform, useProfile, useStreamingServer, useRouteFocused, withCoreSuspender } from 'stremio/common';
 import { MainNavBars } from 'stremio/components';
+import { RouteLoading } from 'stremio/components/RouteLoading';
 import { SECTIONS } from './constants';
 import Menu from './Menu';
 import General from './General';
@@ -120,8 +121,6 @@ const Settings = () => {
     );
 };
 
-const SettingsFallback = () => (
-    <MainNavBars className={styles['settings-container']} route={'settings'} />
-);
+const SettingsFallback = () => <RouteLoading pathname={'/settings'} />;
 
 export default withCoreSuspender(Settings, SettingsFallback);

--- a/tests/route.spec.js
+++ b/tests/route.spec.js
@@ -1,0 +1,37 @@
+/** @jest-environment jsdom */
+
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const React = require('react');
+const { describe, expect, jest, test } = require('@jest/globals');
+const { render, screen } = require('@testing-library/react');
+
+jest.mock('stremio/common/useRouteFocused', () => ({
+    RouteFocusedProvider: ({ children }) => children,
+}));
+
+jest.mock('../src/router/ModalsContainerContext', () => ({
+    ModalsContainerProvider: ({ children }) => children,
+}));
+
+jest.mock('stremio/components/RouteLoading', () => ({
+    RouteLoading: ({ pathname }) => React.createElement('div', { role: 'status' }, `Loading ${pathname}`),
+}));
+
+jest.mock('../src/router/Route/RouteErrorBoundary', () => ({
+    RouteErrorBoundary: ({ children }) => children,
+    RouteReady: () => React.createElement('div', { 'data-route-ready': true }),
+}));
+
+const Route = require('../src/router/Route/Route');
+
+describe('Route', () => {
+    test('renders a visible fallback while a lazy route is pending', () => {
+        const PendingRoute = React.lazy(() => new Promise(() => {}));
+
+        render(<Route component={<PendingRoute />} focused={true} pathname={'/discover'} />);
+
+        expect(screen.getByRole('status').textContent).toBe('Loading /discover');
+        expect(document.querySelector('[data-route-ready]')).toBeNull();
+    });
+});

--- a/tests/routeLoading.spec.js
+++ b/tests/routeLoading.spec.js
@@ -1,0 +1,80 @@
+/** @jest-environment jsdom */
+
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const React = require('react');
+const { afterEach, describe, expect, jest, test } = require('@jest/globals');
+const { fireEvent, render, screen } = require('@testing-library/react');
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock('stremio/components/Button', () => {
+    const React = require('react');
+    const Button = ({ children, onClick }) => React.createElement('button', { onClick }, children);
+    return { default: Button };
+});
+
+jest.mock('stremio/components/MainNavBars', () => {
+    const React = require('react');
+    const MainNavBars = ({ children, route }) => React.createElement('div', { 'data-route': route }, children);
+    return { default: MainNavBars };
+});
+
+jest.mock('../src/components/RouteLoading/RouteLoading.less', () => new Proxy({}, {
+    get: (_, property) => property,
+}));
+
+const { RouteLoading, getLoadingPresentation } = require('../src/components/RouteLoading/RouteLoading');
+const { RouteErrorBoundary, isChunkLoadError } = require('../src/router/Route/RouteErrorBoundary');
+
+describe('resilient route loading', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test.each([
+        ['/discover/https%3A%2F%2Fexample.com/movie/catalog', 'grid', 'discover'],
+        ['/calendar/2026/7', 'calendar', 'calendar'],
+        ['/addons', 'addons', 'addons'],
+        ['/settings', 'settings', 'settings'],
+        ['/detail/movie/tt123', 'details', 'metadetails'],
+        ['/player/stream', 'player', null],
+    ])('selects contextual loading UI for %s', (pathname, kind, route) => {
+        expect(getLoadingPresentation(pathname)).toEqual({ kind, route });
+    });
+
+    test('keeps the selected navigation visible while a route loads', () => {
+        const { container } = render(<RouteLoading pathname={'/calendar/2026/7'} />);
+
+        expect(screen.getByRole('status').getAttribute('aria-busy')).toBe('true');
+        expect(container.querySelector('[data-route="calendar"]')).toBeTruthy();
+        expect(container.querySelectorAll('.calendar-cell')).toHaveLength(35);
+    });
+
+    test('classifies only dynamic chunk failures as reloadable', () => {
+        expect(isChunkLoadError(Object.assign(new Error('network'), { name: 'ChunkLoadError' }))).toBe(true);
+        expect(isChunkLoadError(new Error('Failed to fetch dynamically imported module'))).toBe(true);
+        expect(isChunkLoadError(new Error('regular render failure'))).toBe(false);
+    });
+
+    test('shows recovery actions when a route render fails', () => {
+        const onError = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const BrokenRoute = () => {
+            throw new Error('regular render failure');
+        };
+
+        render(
+            <RouteErrorBoundary pathname={'/discover'}>
+                <BrokenRoute />
+            </RouteErrorBoundary>
+        );
+
+        expect(screen.getByRole('alert').textContent).toContain('GENERIC_ERROR_MESSAGE');
+        expect(screen.getByRole('button', { name: 'TRY_AGAIN' })).toBeTruthy();
+        fireEvent.click(screen.getByRole('button', { name: 'WEBSITE_GO_HOME' }));
+        expect(window.location.hash).toBe('#/');
+        onError.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary
- keep navigation visible and show contextual skeletons while lazy routes load
- recover once automatically from stale chunk errors, then expose Retry and Home actions
- use the details skeleton while metadata is still loading to avoid a dark empty page

## Validation
- `pnpm lint`
- full Jest suite: 17 suites, 124 tests
- production webpack build
- real Tauri release smoke test across Discover, Calendar, Addons, auth and movie details

Closes #63