### PR TITLE
fix: refine card borders and episode status alignment

### DIFF
--- a/src/components/MetaItem/styles.less
+++ b/src/components/MetaItem/styles.less
@@ -24,15 +24,15 @@
 
         .visual-container {
             transform: scale(1.03);
-
-            &::after {
-                border-color: rgba(255, 255, 255, 0.7);
-            }
         }
 
         .poster-container {
             box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
             transform: none;
+
+            &::after {
+                border-color: rgba(255, 255, 255, 0.7);
+            }
 
             .dismiss-icon-layer {
                 opacity: 1;
@@ -102,6 +102,23 @@
             .poster-container {
                 transform: none;
                 box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.55);
+
+                &::after {
+                    border-color: transparent;
+                }
+            }
+        }
+
+        .visual-container {
+            &::after {
+                content: '';
+                position: absolute;
+                inset: 0;
+                z-index: 3;
+                border: 2px solid transparent;
+                border-radius: var(--border-radius);
+                pointer-events: none;
+                transition: border-color 0.2s ease;
             }
         }
 
@@ -160,6 +177,14 @@
         width: 100%;
         transform-origin: center;
         transition: transform 0.2s ease;
+    }
+
+    .poster-container {
+        position: relative;
+        z-index: 0;
+        background-color: var(--overlay-color);
+        border-radius: var(--border-radius);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
 
         &::after {
             content: '';
@@ -171,14 +196,6 @@
             pointer-events: none;
             transition: border-color 0.2s ease;
         }
-    }
-
-    .poster-container {
-        position: relative;
-        z-index: 0;
-        background-color: var(--overlay-color);
-        border-radius: var(--border-radius);
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
 
         &:global(.poster-change-cursor) {
             .poster-image-layer {

--- a/src/components/Video/Video.js
+++ b/src/components/Video/Video.js
@@ -171,6 +171,10 @@ const Video = ({ className, id, title, thumbnail, season, episode, released, upc
                                     :
                                     null
                         }
+                    </div>
+                </div>
+                {
+                    upcoming || watched ?
                         <div className={styles['upcoming-watched-container']}>
                             {
                                 upcoming && !watched ?
@@ -190,8 +194,9 @@ const Video = ({ className, id, title, thumbnail, season, episode, released, upc
                                     null
                             }
                         </div>
-                    </div>
-                </div>
+                        :
+                        null
+                }
                 {
                     typeof onDownload === 'function' ?
                         <Button

--- a/src/components/Video/styles.less
+++ b/src/components/Video/styles.less
@@ -124,56 +124,58 @@
                 opacity: 0.44;
             }
 
-            .upcoming-watched-container {
-                flex: 0 1 auto;
-                display: flex;
-                flex-direction: row;
-                align-items: center;
-                height: 1.6rem;
-                border-radius: 0.3rem;
+        }
+    }
 
-                &>:nth-child(2) {
-                    margin-left: 0.5rem;
-                }
+    .upcoming-watched-container {
+        flex: 0 1 auto;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        height: 1.6rem;
+        margin-right: 0.75rem;
+        border-radius: 0.3rem;
 
-                .upcoming-container,
-                .watched-container {
-                    flex: none;
-                    display: flex;
-                    align-items: center;
-                    height: 100%;
-                    padding: 0 0.5rem;
-                    max-width: 10rem;
+        &>:nth-child(2) {
+            margin-left: 0.5rem;
+        }
 
-                    &:not(:only-child) {
-                        max-width: 5rem;
-                    }
+        .upcoming-container,
+        .watched-container {
+            flex: none;
+            display: flex;
+            align-items: center;
+            height: 100%;
+            padding: 0 0.5rem;
+            max-width: 10rem;
 
-                    .flag-icon {
-                        height: 1.15rem;
-                        width: 1.15rem;
-                        margin-right: 0.25rem;
-                        color: var(--secondary-foreground-color);
-                    }
-
-                    .flag-label {
-                        font-size: 0.8rem;
-                        font-weight: 800;
-                        white-space: nowrap;
-                        text-overflow: ellipsis;
-                        text-transform: uppercase;
-                        color: var(--secondary-foreground-color);
-                    }
-                }
-
-                .upcoming-container {
-                    background-color: var(--secondary-accent-color);
-                }
-
-                .watched-container {
-                    background-color: var(--tertiary-accent-color);
-                }
+            &:not(:only-child) {
+                max-width: 5rem;
             }
+
+            .flag-icon {
+                height: 1.15rem;
+                width: 1.15rem;
+                margin-right: 0.25rem;
+                color: var(--secondary-foreground-color);
+            }
+
+            .flag-label {
+                font-size: 0.8rem;
+                font-weight: 800;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+                text-transform: uppercase;
+                color: var(--secondary-foreground-color);
+            }
+        }
+
+        .upcoming-container {
+            background-color: var(--secondary-accent-color);
+        }
+
+        .watched-container {
+            background-color: var(--tertiary-accent-color);
         }
     }
 


### PR DESCRIPTION
## Résumé

- limite la bordure des posters classiques à leur image
- conserve la bordure au-dessus du dégradé pour Continuer de regarder
- aligne les badges Regardé/À venir avec les actions des épisodes

## Validation

- 145 tests passent
- lint et vérification du diff passent
- bundle natif vérifié visuellement
