### PR TITLE
feat: support Discord RPC in Tauri

### DIFF
--- a/src/common/Discord/Discord.tsx
+++ b/src/common/Discord/Discord.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { usePlatform } from '../Platform';
+import { invokeTauri, isTauri } from '../tauri';
 import useProfile from '../useProfile';
 import type { DiscordActivity as Activity } from './activity';
 
@@ -30,7 +31,8 @@ const DiscordProvider = ({ children }: Props) => {
     const { shell } = usePlatform();
     const profile = useProfile();
     const enabled = profile.settings?.discordRpcEnabled === true;
-    const available = shell.active === true;
+    const tauriAvailable = isTauri();
+    const available = shell.active === true || tauriAvailable;
     const [connected, setConnected] = useState(false);
     const [activity, setActivityState] = useState<Activity | null>(null);
     const sentActivity = useRef<Activity | null>(null);
@@ -39,7 +41,7 @@ const DiscordProvider = ({ children }: Props) => {
     shellRef.current = shell;
 
     useEffect(() => {
-        if (!available) return;
+        if (!shell.active) return;
 
         const onStatus = (data: { connected: boolean }) => {
             connectRequested.current = false;
@@ -51,7 +53,7 @@ const DiscordProvider = ({ children }: Props) => {
         return () => {
             shellRef.current.off('discord-status', onStatus);
         };
-    }, [available]);
+    }, [shell.active]);
 
     useEffect(() => {
         if (!available) {
@@ -64,7 +66,13 @@ const DiscordProvider = ({ children }: Props) => {
         if (!enabled) {
             connectRequested.current = false;
             if (connected) {
-                shellRef.current.send('discord-disconnect', {});
+                if (tauriAvailable) {
+                    invokeTauri('discord_disconnect')
+                        .catch(() => undefined)
+                        .finally(() => setConnected(false));
+                } else {
+                    shellRef.current.send('discord-disconnect', {});
+                }
             }
             sentActivity.current = null;
             return;
@@ -75,7 +83,16 @@ const DiscordProvider = ({ children }: Props) => {
         const requestConnect = () => {
             if (!connectRequested.current) {
                 connectRequested.current = true;
-                shellRef.current.send('discord-connect', {});
+                if (tauriAvailable) {
+                    invokeTauri<boolean>('discord_connect')
+                        .then((isConnected) => setConnected(isConnected === true))
+                        .catch(() => setConnected(false))
+                        .finally(() => {
+                            connectRequested.current = false;
+                        });
+                } else {
+                    shellRef.current.send('discord-connect', {});
+                }
             }
         };
 
@@ -85,14 +102,18 @@ const DiscordProvider = ({ children }: Props) => {
         return () => {
             window.clearInterval(interval);
         };
-    }, [available, connected, enabled]);
+    }, [available, connected, enabled, tauriAvailable]);
 
     useEffect(() => {
         if (!available || !enabled || !connected) return;
 
         if (activity === null) {
             if (sentActivity.current !== null) {
-                shellRef.current.send('discord-clear-activity', {});
+                if (tauriAvailable) {
+                    invokeTauri('discord_clear_activity').catch(() => setConnected(false));
+                } else {
+                    shellRef.current.send('discord-clear-activity', {});
+                }
                 sentActivity.current = null;
             }
             return;
@@ -100,15 +121,24 @@ const DiscordProvider = ({ children }: Props) => {
 
         if (sameActivity(sentActivity.current, activity)) return;
 
-        shellRef.current.send('discord-set-activity', {
+        const payload = {
             state: activity.state,
             details: activity.details || '',
             image: activity.image || null,
             startTimestamp: activity.startTimestamp || null,
             endTimestamp: activity.endTimestamp || null,
-        });
+        };
+        if (tauriAvailable) {
+            invokeTauri('discord_set_activity', { activity: payload })
+                .catch(() => {
+                    sentActivity.current = null;
+                    setConnected(false);
+                });
+        } else {
+            shellRef.current.send('discord-set-activity', payload);
+        }
         sentActivity.current = activity;
-    }, [activity, available, connected, enabled]);
+    }, [activity, available, connected, enabled, tauriAvailable]);
 
     const setActivity = useCallback((nextActivity: Activity | null) => {
         setActivityState((currentActivity) => sameActivity(currentActivity, nextActivity) ? currentActivity : nextActivity);

--- a/src/horizon-translations.js
+++ b/src/horizon-translations.js
@@ -33,6 +33,8 @@ module.exports = {
         HORIZON_PLAYBACK_GENERIC_ERROR: 'Playback could not start. Open the title to choose a source manually.',
         HORIZON_SCROLL_PREVIOUS: 'Previous titles',
         HORIZON_SCROLL_NEXT: 'More titles',
+        HORIZON_UPDATES: 'Updates',
+        HORIZON_AUTOMATIC_UPDATE_CHECKS: 'Automatic update checks',
     },
     'fr-FR': {
         DOWNLOADS: 'Téléchargements',
@@ -82,5 +84,8 @@ module.exports = {
         HORIZON_PLAYBACK_GENERIC_ERROR: 'La lecture n’a pas pu démarrer. Ouvrez la fiche pour choisir une source manuellement.',
         HORIZON_SCROLL_PREVIOUS: 'Titres précédents',
         HORIZON_SCROLL_NEXT: 'Plus de titres',
+        HORIZON_UPDATES: 'Mises à jour',
+        HORIZON_AUTOMATIC_UPDATE_CHECKS: 'Recherche automatique des mises à jour',
+        SETTINGS_DISCORD: 'Afficher l’activité de visionnage sur Discord',
     },
 };

--- a/src/routes/Settings/General/General.tsx
+++ b/src/routes/Settings/General/General.tsx
@@ -164,8 +164,8 @@ const General = forwardRef<HTMLDivElement, Props>(({ profile }: Props, ref) => {
             }
             {
                 isTauri() &&
-                    <Category icon={'download'} label={'Updates'}>
-                        <Option label={'Automatic update checks'}>
+                    <Category icon={'download'} label={t('HORIZON_UPDATES')}>
+                        <Option label={t('HORIZON_AUTOMATIC_UPDATE_CHECKS')}>
                             <Toggle
                                 tabIndex={-1}
                                 checked={autoUpdateEnabled === true}

--- a/tests/discordTauri.spec.tsx
+++ b/tests/discordTauri.spec.tsx
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React, { useEffect } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { clearMocks, mockIPC } from '@tauri-apps/api/mocks';
+import { DiscordProvider, useDiscord } from 'stremio/common/Discord';
+
+const mockShell = {
+    active: false,
+    on: jest.fn(),
+    off: jest.fn(),
+    send: jest.fn(),
+};
+
+let mockDiscordEnabled = false;
+
+jest.mock('stremio/common/Platform', () => ({
+    usePlatform: () => ({ shell: mockShell }),
+}));
+
+jest.mock('stremio/common/useProfile', () => ({
+    __esModule: true,
+    default: () => ({ settings: { discordRpcEnabled: mockDiscordEnabled } }),
+}));
+
+const Harness = ({ publish }: { publish: boolean }) => {
+    const discord = useDiscord();
+
+    useEffect(() => {
+        if (!publish) return;
+        discord.setActivity({
+            state: 'Watching',
+            details: 'Hunter x Hunter · S1:E57',
+            image: 'https://example.com/episode.jpg',
+        });
+    }, [discord.setActivity, publish]);
+
+    return <div data-available={discord.available} data-connected={discord.connected} />;
+};
+
+describe('Discord RPC in Tauri', () => {
+    const commands: string[] = [];
+
+    beforeEach(() => {
+        commands.length = 0;
+        mockDiscordEnabled = false;
+        mockIPC((cmd: string) => {
+            commands.push(cmd);
+            if (cmd === 'discord_connect') return true;
+            return null;
+        });
+    });
+
+    afterEach(() => {
+        clearMocks();
+        jest.clearAllMocks();
+    });
+
+    test('stays private until enabled, then publishes and disconnects when disabled', async () => {
+        const view = render(
+            <DiscordProvider>
+                <Harness publish />
+            </DiscordProvider>
+        );
+
+        expect(view.container.firstElementChild?.getAttribute('data-available')).toBe('true');
+        expect(commands).not.toContain('discord_connect');
+
+        await act(async () => {
+            mockDiscordEnabled = true;
+            view.rerender(
+                <DiscordProvider>
+                    <Harness publish />
+                </DiscordProvider>
+            );
+        });
+
+        await waitFor(() => expect(commands).toContain('discord_connect'));
+        await waitFor(() => expect(commands).toContain('discord_set_activity'));
+
+        await act(async () => {
+            mockDiscordEnabled = false;
+            view.rerender(
+                <DiscordProvider>
+                    <Harness publish />
+                </DiscordProvider>
+            );
+        });
+
+        await waitFor(() => expect(commands).toContain('discord_disconnect'));
+    });
+});


### PR DESCRIPTION
## Résumé

- rend Discord RPC disponible dans la build Tauri
- conserve une activation explicite et désactivée par défaut
- publie lecture, pause, progression et visuel via les commandes natives
- traduit les réglages Discord et mises à jour en français

## Validation

- 23 suites / 146 tests passent
- lint et vérification du diff passent
- réglage vérifié dans le bundle natif
