### PR TITLE
perf: reduce initial bundle size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
         run: pnpm install
       - name: Build
         run: pnpm build
+      - name: Check initial bundle budget and lazy routes
+        run: pnpm bundle:check
       - name: Test
         run: pnpm test
       - name: Lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /node_modules
 /build
+/*-stats.json
+/.bundle-stats.json
 /yarn.lock
 /npm-debug.log
 .DS_Store

--- a/bundle-size-budget.json
+++ b/bundle-size-budget.json
@@ -1,0 +1,13 @@
+{
+    "initialJavaScript": {
+        "raw": 1200000,
+        "gzip": 350000,
+        "brotli": 300000
+    },
+    "requiredLazyRoutes": [
+        "addons",
+        "metadetails",
+        "player",
+        "settings"
+    ]
+}

--- a/docs/performance/initial-bundle.md
+++ b/docs/performance/initial-bundle.md
@@ -1,0 +1,40 @@
+# Initial bundle report
+
+Issue: [#40](https://github.com/Aqu1tain/stremio-horizon/issues/40)
+
+The comparison uses the latest release before this work, `v0.1.8` (`742315f6c`), rather than the older `v0.1.5` snapshot mentioned when the issue was written. Both builds use the same Node, pnpm, lockfile, production webpack configuration, and compression settings.
+
+## Initial JavaScript
+
+Only same-origin scripts referenced by `build/index.html` are counted. Source maps, lazy routes, optional locale chunks, and the core WASM binary are excluded.
+
+| Build | Raw | gzip | Brotli |
+| --- | ---: | ---: | ---: |
+| v0.1.8 | 8,937,433 B | 2,630,092 B | 1,332,984 B |
+| Optimized | 1,042,569 B | 289,380 B | 236,297 B |
+| Reduction | 88.3% | 89.0% | 82.3% |
+
+The v0.1.8 total includes `worker.js` because HtmlWebpackPlugin injected both webpack entry points. The optimized page references only `main.js`; the core worker remains emitted and is created explicitly by `src/core/createTransport.ts`.
+
+## Largest eager modules before
+
+The production webpack profile identified two avoidable groups:
+
+- Every JSON file from `stremio-translations` was included eagerly. The package contains roughly 5.9 MiB of locale JSON before minification.
+- Importing named icons from the Lucide barrel retained its complete 1,677-icon module graph (roughly 1.5 MiB before minification).
+- The legacy Stremio icon set added roughly 173 KiB before minification even when no legacy-only icon was visible.
+
+## Changes
+
+- `en-US` remains in the initial entry point; other locales are emitted as independent chunks and fetched when the interface language changes.
+- Horizon-specific strings are merged into each locale after it is loaded.
+- Lucide icons use direct per-icon modules.
+- The legacy icon set is loaded only when a legacy-only icon is rendered.
+- Optional locale and legacy-icon chunks use an on-demand runtime cache instead of being precached wholesale by the service worker.
+- HtmlWebpackPlugin injects only the main entry point. The dedicated worker entry is still available at its existing URL.
+
+## Guardrails
+
+`pnpm bundle:check` measures the production files with raw, gzip level 9, and Brotli quality 11 compression. CI rejects changes above the limits in `bundle-size-budget.json` and verifies that Addons, MetaDetails, Player, and Settings still emit independent production chunks.
+
+The core WASM payload is reported separately. It is currently 4,805,206 B and is not counted as JavaScript.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
         "start": "webpack serve --mode development",
         "start-prod": "webpack serve --mode production",
         "build": "webpack --mode production",
+        "bundle:report": "node scripts/check-bundle-size.js",
+        "bundle:check": "node scripts/check-bundle-size.js --check",
         "test": "jest",
         "lint": "eslint src",
         "scan-translations": "pnpx jest ./tests/i18nScan.test.js"

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -1,0 +1,102 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+const budget = require('../bundle-size-budget.json');
+
+const root = path.resolve(__dirname, '..');
+const buildDirectory = path.join(root, 'build');
+const indexPath = path.join(buildDirectory, 'index.html');
+const checkBudget = process.argv.includes('--check');
+
+const formatBytes = (bytes) => `${(bytes / 1024).toFixed(1)} KiB`;
+
+if (!fs.existsSync(indexPath)) {
+    throw new Error('Production build not found. Run `pnpm build` first.');
+}
+
+const html = fs.readFileSync(indexPath, 'utf8');
+const scriptSources = Array.from(html.matchAll(/<script\b[^>]*\bsrc="([^"]+)"/g), (match) => match[1])
+    .filter((source) => !source.startsWith('//') && !/^https?:/.test(source) && source.endsWith('.js'));
+
+if (scriptSources.length === 0) {
+    throw new Error('No initial JavaScript entry point was found in build/index.html.');
+}
+
+const initialAssets = scriptSources.map((source) => {
+    const filePath = path.join(buildDirectory, source);
+    const contents = fs.readFileSync(filePath);
+    return {
+        source,
+        raw: contents.length,
+        gzip: zlib.gzipSync(contents, { level: 9 }).length,
+        brotli: zlib.brotliCompressSync(contents, {
+            params: {
+                [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+            },
+        }).length,
+    };
+});
+
+const totals = initialAssets.reduce((result, asset) => ({
+    raw: result.raw + asset.raw,
+    gzip: result.gzip + asset.gzip,
+    brotli: result.brotli + asset.brotli,
+}), { raw: 0, gzip: 0, brotli: 0 });
+
+console.log('Initial JavaScript');
+initialAssets.forEach((asset) => {
+    console.log(`- ${asset.source}: ${formatBytes(asset.raw)} raw, ${formatBytes(asset.gzip)} gzip, ${formatBytes(asset.brotli)} Brotli`);
+});
+console.log(`- total: ${formatBytes(totals.raw)} raw, ${formatBytes(totals.gzip)} gzip, ${formatBytes(totals.brotli)} Brotli`);
+
+const wasmAssets = [];
+const visit = (directory) => {
+    fs.readdirSync(directory, { withFileTypes: true }).forEach((entry) => {
+        const entryPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+            visit(entryPath);
+        } else if (entry.name.endsWith('.wasm')) {
+            wasmAssets.push(entryPath);
+        }
+    });
+};
+visit(buildDirectory);
+const wasmBytes = wasmAssets.reduce((total, filePath) => total + fs.statSync(filePath).size, 0);
+console.log(`Core WASM (tracked separately): ${formatBytes(wasmBytes)}`);
+
+const initialScriptsDirectory = path.dirname(path.join(buildDirectory, initialAssets[0].source));
+const emittedScripts = fs.readdirSync(initialScriptsDirectory);
+const missingLazyRoutes = budget.requiredLazyRoutes.filter((route) => {
+    return !emittedScripts.some((fileName) => new RegExp(`^${route}\\.[a-f0-9]+\\.js$`).test(fileName));
+});
+
+if (missingLazyRoutes.length > 0) {
+    throw new Error(`Missing production lazy-route chunks: ${missingLazyRoutes.join(', ')}`);
+}
+console.log(`Lazy-route smoke check: ${budget.requiredLazyRoutes.join(', ')}`);
+
+const serviceWorkerPath = path.join(buildDirectory, 'service-worker.js');
+if (fs.existsSync(serviceWorkerPath)) {
+    const serviceWorker = fs.readFileSync(serviceWorkerPath, 'utf8');
+    const precachedAssets = Array.from(serviceWorker.matchAll(/url:"([^"]+)"/g), (match) => match[1]);
+    const eagerlyCachedOptionalAssets = precachedAssets.filter((asset) => {
+        return asset.includes('locale-') || asset.includes('legacy-icons.') || asset.endsWith('.map');
+    });
+    if (eagerlyCachedOptionalAssets.length > 0) {
+        throw new Error(`Optional assets must be cached on demand: ${eagerlyCachedOptionalAssets.join(', ')}`);
+    }
+    console.log('Service-worker optional chunks: cached on demand');
+}
+
+if (checkBudget) {
+    const exceeded = Object.entries(budget.initialJavaScript)
+        .filter(([encoding, limit]) => totals[encoding] > limit)
+        .map(([encoding, limit]) => `${encoding}: ${formatBytes(totals[encoding])} > ${formatBytes(limit)}`);
+
+    if (exceeded.length > 0) {
+        throw new Error(`Initial JavaScript budget exceeded:\n${exceeded.join('\n')}`);
+    }
+    console.log('Initial JavaScript budget: passed');
+}

--- a/src/App/GamepadModal/GamepadModal.tsx
+++ b/src/App/GamepadModal/GamepadModal.tsx
@@ -3,8 +3,7 @@
 import React, { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import Icon from '@stremio/stremio-icons/react';
-import { Button } from 'stremio/components';
+import { Button, Icon } from 'stremio/components';
 import { useGamepad } from 'stremio/services';
 import type { ControllerType } from 'stremio/services/GamepadContext';
 import GamepadDiagram from './GamepadDiagram';

--- a/src/common/translationBackend.js
+++ b/src/common/translationBackend.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const loadTranslations = (language) => import(
+    /* webpackChunkName: "locale-[request]" */
+    /* webpackInclude: /[a-z]{2}-[A-Z]{2}\.json$/ */
+    `stremio-translations/${language}.json`
+);
+
+const createTranslationBackend = (overrides, loader = loadTranslations) => ({
+    type: 'backend',
+    init: () => undefined,
+    read: (language, _namespace, callback) => {
+        loader(language)
+            .then((translationModule) => callback(null, {
+                ...(translationModule.default || translationModule),
+                ...(overrides[language] || {})
+            }))
+            .catch((error) => callback(error, false));
+    }
+});
+
+module.exports = {
+    createTranslationBackend,
+};

--- a/src/components/ActionsGroup/ActionsGroup.tsx
+++ b/src/components/ActionsGroup/ActionsGroup.tsx
@@ -2,9 +2,13 @@
 
 import classNames from 'classnames';
 import React from 'react';
-import Icon from '@stremio/stremio-icons/react';
 import { Tooltip } from 'stremio/common/Tooltips';
 import styles from './ActionsGroup.less';
+
+const Icon = React.lazy(() => import(
+    /* webpackChunkName: "legacy-icons" */
+    '@stremio/stremio-icons/react'
+).then((module) => ({ default: module.default })));
 
 type Item = {
     icon: string;
@@ -35,7 +39,9 @@ const ActionsGroup = ({ items, className }: Props) => {
                             item.label &&
                                 <Tooltip label={item.label} position={'top'} />
                         }
-                        <Icon name={item.icon} className={styles['icon']} />
+                        <React.Suspense fallback={null}>
+                            <Icon name={item.icon} className={styles['icon']} />
+                        </React.Suspense>
                     </div>
                 ))
             }

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,19 +1,60 @@
 import React, { forwardRef } from 'react';
-import {
-    Play, Pause, X, Search, Settings, Download, Share2, Link,
-    ChevronLeft, ChevronRight, ChevronDown, Check,
-    MoreHorizontal, MoreVertical, Plus, Minus, Trash2,
-    Eye, Info, HelpCircle, User, UserRound,
-    RotateCcw, SkipForward, Maximize, Minimize,
-    VolumeOff, VolumeX, Volume, Volume1, Volume2,
-    Calendar, Cast, Globe, Gauge,
-    Heart, ThumbsUp, CircleAlert,
-    Captions, AudioLines, ListVideo, SlidersHorizontal,
-    Clapperboard, Users, Megaphone, Glasses, Smartphone, Keyboard, Copy,
-    PictureInPicture2,
-} from 'lucide-react';
+import Play from 'lucide-react/dist/esm/icons/play.js';
+import Pause from 'lucide-react/dist/esm/icons/pause.js';
+import X from 'lucide-react/dist/esm/icons/x.js';
+import Search from 'lucide-react/dist/esm/icons/search.js';
+import Settings from 'lucide-react/dist/esm/icons/settings.js';
+import Download from 'lucide-react/dist/esm/icons/download.js';
+import Share2 from 'lucide-react/dist/esm/icons/share-2.js';
+import Link from 'lucide-react/dist/esm/icons/link.js';
+import ChevronLeft from 'lucide-react/dist/esm/icons/chevron-left.js';
+import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right.js';
+import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down.js';
+import Check from 'lucide-react/dist/esm/icons/check.js';
+import MoreHorizontal from 'lucide-react/dist/esm/icons/ellipsis.js';
+import MoreVertical from 'lucide-react/dist/esm/icons/ellipsis-vertical.js';
+import Plus from 'lucide-react/dist/esm/icons/plus.js';
+import Minus from 'lucide-react/dist/esm/icons/minus.js';
+import Trash2 from 'lucide-react/dist/esm/icons/trash-2.js';
+import Eye from 'lucide-react/dist/esm/icons/eye.js';
+import Info from 'lucide-react/dist/esm/icons/info.js';
+import HelpCircle from 'lucide-react/dist/esm/icons/circle-question-mark.js';
+import User from 'lucide-react/dist/esm/icons/user.js';
+import UserRound from 'lucide-react/dist/esm/icons/circle-user-round.js';
+import RotateCcw from 'lucide-react/dist/esm/icons/rotate-ccw.js';
+import SkipForward from 'lucide-react/dist/esm/icons/skip-forward.js';
+import Maximize from 'lucide-react/dist/esm/icons/maximize.js';
+import Minimize from 'lucide-react/dist/esm/icons/minimize.js';
+import VolumeOff from 'lucide-react/dist/esm/icons/volume-off.js';
+import VolumeX from 'lucide-react/dist/esm/icons/volume-x.js';
+import Volume from 'lucide-react/dist/esm/icons/volume.js';
+import Volume1 from 'lucide-react/dist/esm/icons/volume-1.js';
+import Volume2 from 'lucide-react/dist/esm/icons/volume-2.js';
+import Calendar from 'lucide-react/dist/esm/icons/calendar.js';
+import Cast from 'lucide-react/dist/esm/icons/cast.js';
+import Globe from 'lucide-react/dist/esm/icons/globe.js';
+import Gauge from 'lucide-react/dist/esm/icons/gauge.js';
+import Heart from 'lucide-react/dist/esm/icons/heart.js';
+import ThumbsUp from 'lucide-react/dist/esm/icons/thumbs-up.js';
+import CircleAlert from 'lucide-react/dist/esm/icons/circle-alert.js';
+import Captions from 'lucide-react/dist/esm/icons/captions.js';
+import AudioLines from 'lucide-react/dist/esm/icons/audio-lines.js';
+import ListVideo from 'lucide-react/dist/esm/icons/list-video.js';
+import SlidersHorizontal from 'lucide-react/dist/esm/icons/sliders-horizontal.js';
+import Clapperboard from 'lucide-react/dist/esm/icons/clapperboard.js';
+import Users from 'lucide-react/dist/esm/icons/users.js';
+import Megaphone from 'lucide-react/dist/esm/icons/megaphone.js';
+import Glasses from 'lucide-react/dist/esm/icons/glasses.js';
+import Smartphone from 'lucide-react/dist/esm/icons/smartphone.js';
+import Keyboard from 'lucide-react/dist/esm/icons/keyboard.js';
+import Copy from 'lucide-react/dist/esm/icons/copy.js';
+import PictureInPicture2 from 'lucide-react/dist/esm/icons/picture-in-picture-2.js';
 import type { LucideIcon } from 'lucide-react';
-import StremioIcon from '@stremio/stremio-icons/react';
+
+const StremioIcon = React.lazy(() => import(
+    /* webpackChunkName: "legacy-icons" */
+    '@stremio/stremio-icons/react'
+).then((module) => ({ default: module.default })));
 
 const LUCIDE_MAP: Record<string, LucideIcon> = {
     'play': Play,
@@ -95,7 +136,11 @@ const Icon = forwardRef<SVGSVGElement, IconProps>(({ name, className }, ref) => 
         );
     }
 
-    return <StremioIcon ref={ref} name={name} className={className} />;
+    return (
+        <React.Suspense fallback={null}>
+            <StremioIcon ref={ref} name={name} className={className} />
+        </React.Suspense>
+    );
 });
 
 Icon.displayName = 'Icon';

--- a/src/index.js
+++ b/src/index.js
@@ -16,25 +16,32 @@ const ReactDOM = require('react-dom/client');
 const { HashRouter } = require('react-router-dom');
 const i18n = require('i18next');
 const { initReactI18next } = require('react-i18next');
-const stremioTranslations = require('stremio-translations');
 const horizonTranslations = require('./horizon-translations');
+const { createTranslationBackend } = require('./common/translationBackend');
 const App = require('./App');
 const { CoreProvider } = require('./core');
 const { FileDropProvider, PlatformProvider } = require('./common');
 
-const translations = Object.fromEntries(Object.entries(stremioTranslations()).map(([key, value]) => [key, {
-    translation: {
-        ...value,
-        ...(horizonTranslations[key] || {})
-    }
-}]));
+const initialLanguage = 'en-US';
+const initialTranslations = require('stremio-translations/en-US.json');
+const translationBackend = createTranslationBackend(horizonTranslations);
 
 i18n
+    .use(translationBackend)
     .use(initReactI18next)
     .init({
-        resources: translations,
-        lng: 'en-US',
-        fallbackLng: 'en-US',
+        resources: {
+            [initialLanguage]: {
+                translation: {
+                    ...initialTranslations,
+                    ...(horizonTranslations[initialLanguage] || {})
+                }
+            }
+        },
+        partialBundledLanguages: true,
+        load: 'currentOnly',
+        lng: initialLanguage,
+        fallbackLng: initialLanguage,
         interpolation: {
             escapeValue: false
         }

--- a/src/routes/Player/SubtitlesMenu/SubtitleVariant/SubtitleVariant.tsx
+++ b/src/routes/Player/SubtitlesMenu/SubtitleVariant/SubtitleVariant.tsx
@@ -3,9 +3,9 @@
 import React, { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ContextMenu } from 'stremio/components';
+import Icon from 'stremio/components/Icon';
 import { languages, useToast } from 'stremio/common';
 import classNames from 'classnames';
-import Icon from '@stremio/stremio-icons/react';
 import styles from './SubtitleVariant.less';
 
 type SubtitlesTrack = {

--- a/tests/translationBackend.spec.js
+++ b/tests/translationBackend.spec.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2017-2026 Smart code 203358507
+
+const { describe, expect, jest, test } = require('@jest/globals');
+const { createTranslationBackend } = require('../src/common/translationBackend');
+
+describe('translation backend', () => {
+    test('loads one locale and applies Horizon overrides', async () => {
+        const loader = jest.fn().mockResolvedValue({
+            default: {
+                PLAY: 'Lire',
+                DOWNLOADS: 'Téléchargements upstream',
+            }
+        });
+        const backend = createTranslationBackend({
+            'fr-FR': {
+                DOWNLOADS: 'Téléchargements Horizon',
+            }
+        }, loader);
+
+        const translations = await new Promise((resolve, reject) => {
+            backend.read('fr-FR', 'translation', (error, result) => error ? reject(error) : resolve(result));
+        });
+
+        expect(loader).toHaveBeenCalledWith('fr-FR');
+        expect(translations).toEqual({
+            PLAY: 'Lire',
+            DOWNLOADS: 'Téléchargements Horizon',
+        });
+    });
+
+    test('reports a locale chunk loading failure to i18next', async () => {
+        const error = new Error('chunk unavailable');
+        const backend = createTranslationBackend({}, jest.fn().mockRejectedValue(error));
+
+        const result = await new Promise((resolve) => {
+            backend.read('fr-FR', 'translation', (loadError, translations) => resolve({ loadError, translations }));
+        });
+
+        expect(result).toEqual({ loadError: error, translations: false });
+    });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -227,7 +227,25 @@ module.exports = (env, argv) => ({
             new WorkboxPlugin.GenerateSW({
                 maximumFileSizeToCacheInBytes: 20000000,
                 clientsClaim: true,
-                skipWaiting: true
+                skipWaiting: true,
+                exclude: [
+                    /\.map$/,
+                    /scripts\/locale-.*\.js$/,
+                    /scripts\/legacy-icons\..*\.js$/,
+                ],
+                runtimeCaching: [
+                    {
+                        urlPattern: /\/scripts\/(?:locale-|legacy-icons\.).*\.js$/,
+                        handler: 'CacheFirst',
+                        options: {
+                            cacheName: 'optional-ui-chunks',
+                            expiration: {
+                                maxEntries: 60,
+                                maxAgeSeconds: 60 * 60 * 24 * 365,
+                            },
+                        },
+                    },
+                ],
             }),
         new CopyWebpackPlugin({
             patterns: [
@@ -245,6 +263,7 @@ module.exports = (env, argv) => ({
             template: './src/index.html',
             inject: false,
             scriptLoading: 'blocking',
+            chunks: ['main'],
             faviconsPath: 'favicons',
             imagesPath: 'images',
         }),


### PR DESCRIPTION
## What changed

- load only `en-US` in the initial entry point and fetch other locales on demand
- import Lucide icons by module and lazy-load the legacy Stremio icon set
- stop injecting the core worker as an initial page script
- keep optional locale and icon chunks out of the service-worker precache
- add bundle budgets, lazy-route checks, CI enforcement, and a performance report

## Impact

Compared with v0.1.8, initial JavaScript drops from 8,937,433 B to 1,042,569 B raw, from 2,630,092 B to 289,380 B gzip, and from 1,332,984 B to 236,297 B Brotli.

The core worker and WASM remain available, but are no longer counted as blocking initial JavaScript.

## Validation

- 24 test suites / 148 tests pass
- lint passes
- production build passes
- bundle budget and lazy-route checks pass
- native macOS bundle generated and launched locally
- JavaScript, CSS, and dynamic French locale served by the running app match the optimized build byte-for-byte

Closes #40