### PR TITLE
feat: smart episode resume and native VLC playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-08-29
+
+### Added
+
+- Open a series on the season containing its first released unwatched episode and scroll that
+  episode into view automatically
+- Add VLC as a native desktop player option and make it the default when selected
+- Keep Stremio playback progress, resume position and watched completion synchronized while VLC is
+  playing
+- Start VLC with the primary and secondary audio/subtitle language preferences from Stremio, reuse
+  the previously selected external subtitle when available, and respect disabled subtitles
+
 ## [0.1.8] - 2026-08-01
 
 ### Fixed
@@ -172,7 +184,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Lucide icons with stremio-icons fallback
 - Chromecast support (Chrome + Tauri native)
 
-[Unreleased]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.8...HEAD
+[Unreleased]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.9...HEAD
+[0.1.9]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.5...v0.1.6

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "stremio",
     "displayName": "Stremio",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "upstreamVersion": "v5.0.0-beta.39",
     "author": "Smart Code OOD",
     "private": true,

--- a/src/common/CONSTANTS.ts
+++ b/src/common/CONSTANTS.ts
@@ -72,7 +72,7 @@ export const EXTERNAL_PLAYERS: ExternalPlayer[] = [
     {
         label: 'VLC',
         value: 'vlc',
-        platforms: ['ios', 'visionos', 'android'],
+        platforms: ['ios', 'visionos', 'android', 'windows', 'linux', 'macos'],
     },
     {
         label: 'MPV',

--- a/src/components/Video/Video.js
+++ b/src/components/Video/Video.js
@@ -15,7 +15,7 @@ const { usePlatform } = require('stremio/common/Platform');
 const VideoPlaceholder = require('./VideoPlaceholder');
 const styles = require('./styles');
 
-const Video = ({ className, id, title, thumbnail, season, episode, released, upcoming, watched, progress, scheduled, seasonWatched, selected, deepLinks, downloadStatus, downloadBusy, downloadDisabled, onDownload, onSelect, onMarkVideoAsWatched, onMarkSeasonAsWatched, ...props }) => {
+const Video = ({ className, id, title, thumbnail, season, episode, released, upcoming, watched, progress, scheduled, seasonWatched, selected, autoScrollIntoView, deepLinks, downloadStatus, downloadBusy, downloadDisabled, onDownload, onSelect, onMarkVideoAsWatched, onMarkSeasonAsWatched, ...props }) => {
     const routeFocused = useRouteFocused();
     const profile = useProfile();
     const navigate = useNavigate();
@@ -112,7 +112,13 @@ const Video = ({ className, id, title, thumbnail, season, episode, released, upc
         const blurThumbnail = profile.settings.hideSpoilers && season && episode && !watched;
 
         React.useEffect(() => {
-            if (selected && ref.current) {
+            if (autoScrollIntoView && ref.current) {
+                ref.current.scrollIntoView({
+                    behavior: 'auto',
+                    block: 'start',
+                    inline: 'nearest'
+                });
+            } else if (selected && ref.current) {
                 if ((progress && watched) || !watched) {
                     ref.current.scrollIntoView({
                         behavior: 'smooth',
@@ -121,7 +127,7 @@ const Video = ({ className, id, title, thumbnail, season, episode, released, upc
                     });
                 }
             }
-        }, [selected]);
+        }, [autoScrollIntoView, selected]);
 
         return (
             <Button {...props} ref={ref} className={classnames(className, styles['video-container'], { [styles['selected']]: selected, [styles['disabled']]: notPlayable })} title={title}>
@@ -233,7 +239,7 @@ const Video = ({ className, id, title, thumbnail, season, episode, released, upc
                 {children}
             </Button>
         );
-    }, [deepLinks, downloadBusy, downloadButtonOnClick, downloadButtonOnKeyDown, downloadDisabled, downloadStatus, onDownload, playButtonOnClick, playButtonOnKeyDown, selected]);
+    }, [autoScrollIntoView, deepLinks, downloadBusy, downloadButtonOnClick, downloadButtonOnKeyDown, downloadDisabled, downloadStatus, onDownload, playButtonOnClick, playButtonOnKeyDown, selected]);
     const renderMenu = React.useMemo(() => function renderMenu() {
         return (
             <div className={styles['context-menu-content']} onPointerDown={popupMenuOnPointerDown} onContextMenu={popupMenuOnContextMenu} onClick={popupMenuOnClick} onKeyDown={popupMenuOnKeyDown}>
@@ -295,6 +301,7 @@ Video.propTypes = {
     scheduled: PropTypes.bool,
     seasonWatched: PropTypes.bool,
     selected: PropTypes.bool,
+    autoScrollIntoView: PropTypes.bool,
     downloadStatus: PropTypes.string,
     downloadBusy: PropTypes.bool,
     downloadDisabled: PropTypes.bool,

--- a/src/core/types/models/Player.d.ts
+++ b/src/core/types/models/Player.d.ts
@@ -40,6 +40,7 @@ type SubtitlesTrackState = {
 
 type AudioTrackState = {
     id: string,
+    lang?: string,
 };
 
 type StreamState = {

--- a/src/horizon-translations.js
+++ b/src/horizon-translations.js
@@ -35,6 +35,10 @@ module.exports = {
         HORIZON_SCROLL_NEXT: 'More titles',
         HORIZON_UPDATES: 'Updates',
         HORIZON_AUTOMATIC_UPDATE_CHECKS: 'Automatic update checks',
+        HORIZON_PLAYING_IN_VLC: 'Playing in VLC',
+        HORIZON_OPENING_VLC: 'Opening VLC…',
+        HORIZON_CLOSE_VLC_TO_RETURN: 'Close VLC when you are done to return to Stremio Horizon. Your progress will be saved automatically.',
+        HORIZON_VLC_FAILED: 'VLC could not start',
     },
     'fr-FR': {
         DOWNLOADS: 'Téléchargements',
@@ -86,6 +90,10 @@ module.exports = {
         HORIZON_SCROLL_NEXT: 'Plus de titres',
         HORIZON_UPDATES: 'Mises à jour',
         HORIZON_AUTOMATIC_UPDATE_CHECKS: 'Recherche automatique des mises à jour',
+        HORIZON_PLAYING_IN_VLC: 'Lecture dans VLC',
+        HORIZON_OPENING_VLC: 'Ouverture de VLC…',
+        HORIZON_CLOSE_VLC_TO_RETURN: 'Fermez VLC lorsque vous avez terminé pour revenir à Stremio Horizon. Votre progression sera enregistrée automatiquement.',
+        HORIZON_VLC_FAILED: 'VLC n’a pas pu démarrer',
         SETTINGS_DISCORD: 'Afficher l’activité de visionnage sur Discord',
     },
 };

--- a/src/routes/MetaDetails/StreamsList/Stream/Stream.js
+++ b/src/routes/MetaDetails/StreamsList/Stream/Stream.js
@@ -11,6 +11,7 @@ const { Button, Image, Popup } = require('stremio/components');
 const { default: useRouteFocused } = require('stremio/common/useRouteFocused');
 const { default: parseStreamBadges } = require('stremio/common/parseStreamBadges');
 const { downloadsAvailable, startDownload } = require('stremio/lib/downloads');
+const { isTauri } = require('stremio/common/tauri');
 const StreamPlaceholder = require('./StreamPlaceholder');
 const styles = require('./styles');
 
@@ -20,6 +21,7 @@ const Stream = ({ className, videoId, videoReleased, videoTitle, videoSeason, vi
     const platform = usePlatform();
     const core = useCore();
     const routeFocused = useRouteFocused();
+    const nativeVlc = isTauri() && profile.settings.playerType === 'vlc';
 
     const [menuOpen, openMenu, closeMenu, toggleMenu] = useBinaryState(false);
     const [expanded, setExpanded] = React.useState(false);
@@ -69,6 +71,7 @@ const Stream = ({ className, videoId, videoReleased, videoTitle, videoSeason, vi
     }, []);
 
     const href = React.useMemo(() => {
+        if (nativeVlc) return deepLinks?.player ?? null;
         return deepLinks ?
             deepLinks.externalPlayer ?
                 deepLinks.externalPlayer.web ?
@@ -85,7 +88,7 @@ const Stream = ({ className, videoId, videoReleased, videoTitle, videoSeason, vi
                 deepLinks.player
             :
             null;
-    }, [deepLinks]);
+    }, [deepLinks, nativeVlc]);
 
     const download = React.useMemo(() => {
         return href === deepLinks?.externalPlayer?.playlist ?
@@ -130,7 +133,7 @@ const Stream = ({ className, videoId, videoReleased, videoTitle, videoSeason, vi
             return;
         }
 
-        if (profile.settings.playerType !== null) {
+        if (profile.settings.playerType !== null && !nativeVlc) {
             markVideoAsWatched();
             toast.show({
                 type: 'success',
@@ -142,7 +145,7 @@ const Stream = ({ className, videoId, videoReleased, videoTitle, videoSeason, vi
         if (typeof props.onClick === 'function') {
             props.onClick(event);
         }
-    }, [props.onClick, profile.settings, markVideoAsWatched]);
+    }, [props.onClick, profile.settings, markVideoAsWatched, nativeVlc]);
 
     const copyMagnetLink = React.useCallback((event) => {
         event.preventDefault();

--- a/src/routes/MetaDetails/VideosList/VideosList.js
+++ b/src/routes/MetaDetails/VideosList/VideosList.js
@@ -11,6 +11,7 @@ const { downloadsAvailable, listDownloads, listenDownloadChanged, listenDownload
 const { mergeDownload } = require('stremio/routes/Downloads/utils');
 const SeasonsBar = require('./SeasonsBar');
 const { default: EpisodePicker } = require('../EpisodePicker');
+const getFirstUnwatchedVideo = require('./getFirstUnwatchedVideo');
 const styles = require('./styles');
 
 let savedScrollTop = 0;
@@ -43,6 +44,11 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
             return season;
         }
 
+        const firstUnwatchedVideo = getFirstUnwatchedVideo(videos);
+        if (firstUnwatchedVideo && seasons.includes(firstUnwatchedVideo.season)) {
+            return firstUnwatchedVideo.season;
+        }
+
         const video = videos?.find((video) => video.id === libraryItem?.state.video_id);
 
         if (video && video.season && seasons.includes(video.season)) {
@@ -73,6 +79,14 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
     const seasonWatched = React.useMemo(() => {
         return videosForSeason.every((video) => video.watched);
     }, [videosForSeason]);
+    const firstUnwatchedVideo = React.useMemo(() => {
+        return getFirstUnwatchedVideo(videosForSeason, selectedSeason);
+    }, [videosForSeason, selectedSeason]);
+    const contentId = metaItem?.content?.type === 'Ready' ? metaItem.content.content.id : null;
+    const [autoScrollVideoId, setAutoScrollVideoId] = React.useState(null);
+    React.useEffect(() => {
+        setAutoScrollVideoId(firstUnwatchedVideo?.id ?? null);
+    }, [contentId, selectedSeason]);
 
     const videosContainerRef = React.useRef(null);
     const isMountedRef = React.useRef(false);
@@ -246,6 +260,7 @@ const VideosList = ({ className, metaItem, libraryItem, season, seasonOnSelect, 
                                                 scheduled={video.scheduled}
                                                 seasonWatched={seasonWatched}
                                                 selected={video.id === selectedVideoId}
+                                                autoScrollIntoView={video.id === autoScrollVideoId}
                                                 downloadStatus={downloadStatusByVideo.get(video.id) ?? null}
                                                 downloadBusy={resolvingVideoId === video.id}
                                                 downloadDisabled={resolvingVideoId !== null && resolvingVideoId !== video.id}

--- a/src/routes/MetaDetails/VideosList/getFirstUnwatchedVideo.js
+++ b/src/routes/MetaDetails/VideosList/getFirstUnwatchedVideo.js
@@ -1,0 +1,27 @@
+const isReleased = (video) => {
+    return !video.upcoming && video.released instanceof Date && !isNaN(video.released.getTime());
+};
+
+const sortByEpisode = (left, right) => {
+    if ((left.season ?? 0) !== (right.season ?? 0)) {
+        return (left.season ?? 0) - (right.season ?? 0);
+    }
+
+    return (left.episode ?? 0) - (right.episode ?? 0);
+};
+
+const getFirstUnwatchedVideo = (videos, season = null) => {
+    const releasedUnwatched = videos
+        .filter((video) => !video.watched && isReleased(video))
+        .sort(sortByEpisode);
+
+    if (typeof season === 'number') {
+        return releasedUnwatched.find((video) => video.season === season) ?? null;
+    }
+
+    // Specials should not take precedence over the main story, but remain a
+    // valid next episode once every regular episode has been watched.
+    return releasedUnwatched.find((video) => video.season !== 0) ?? releasedUnwatched[0] ?? null;
+};
+
+module.exports = getFirstUnwatchedVideo;

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -15,7 +15,7 @@ const { useSettings, useProfile, useFullscreen, useBinaryState, useToast, useStr
 const { default: toPath } = require('stremio-router/toPath');
 const { isTauri } = require('stremio/common/tauri');
 const { DEFAULT_STREAMING_SERVER_URL } = require('stremio/common/CONSTANTS');
-const { HorizontalNavBar, Transition, ContextMenu } = require('stremio/components');
+const { HorizontalNavBar, Transition, ContextMenu, Icon } = require('stremio/components');
 const { RouteLoading } = require('stremio/components/RouteLoading');
 const { default: Buffering } = require('./Buffering');
 const VolumeChangeIndicator = require('./VolumeChangeIndicator');
@@ -42,6 +42,8 @@ const styles = require('./styles');
 const Video = require('./Video');
 const { default: Indicator } = require('./Indicator/Indicator');
 const { default: useMediaSession } = require('./useMediaSession');
+const { default: useVlcPlayback } = require('./useVlcPlayback');
+const { default: buildVlcPlaybackPreferences } = require('./vlcPlaybackPreferences');
 
 const findTrackByLang = (tracks, lang) => tracks.find((track) => track.lang === lang || langs.where('1', track.lang)?.[2] === lang);
 const findTrackById = (tracks, id) => tracks.find((track) => track.id === id);
@@ -70,6 +72,7 @@ const Player = () => {
         return queryParams.has('forceTranscoding');
     }, [queryParams]);
     const profile = useProfile();
+    const nativeVlc = isTauri() && profile.settings.playerType === 'vlc';
     const [player, videoParamsChanged, streamStateChanged, timeChanged, seek, pausedChanged, ended, nextVideo] = usePlayer(urlParams);
     const downloadContext = React.useMemo(() => {
         const meta = player.metaItem?.type === 'Ready' ? player.metaItem.content : null;
@@ -267,6 +270,56 @@ const Player = () => {
         }
     }, [player.nextVideo, profile.settings.bingeWatching, handleNextVideoNavigation]);
 
+    const vlcStreamUrl = React.useMemo(() => {
+        if (!nativeVlc || player.stream?.type !== 'Ready') return null;
+        return player.stream.content?.url ?? player.selected?.stream?.deepLinks?.externalPlayer?.streaming ?? null;
+    }, [nativeVlc, player.selected, player.stream]);
+    const vlcStartTime = React.useMemo(() => {
+        const selectedVideoId = player.selected?.streamRequest?.path?.id;
+        return player.libraryItem !== null && selectedVideoId && player.libraryItem.state.video_id === selectedVideoId ?
+            player.libraryItem.state.timeOffset
+            :
+            0;
+    }, [player.libraryItem, player.selected]);
+    const vlcPlaybackPreferences = React.useMemo(() => buildVlcPlaybackPreferences({
+        audioLanguage: settings.audioLanguage,
+        secondaryAudioLanguage: settings.secondaryAudioLanguage,
+        subtitlesLanguage: settings.subtitlesLanguage,
+        secondarySubtitlesLanguage: settings.secondarySubtitlesLanguage,
+        savedAudioLanguage: player.streamState?.audioTrack?.lang,
+        savedSubtitle: player.streamState?.subtitleTrack,
+        subtitles: streamSubtitles.concat(Array.isArray(player.subtitles) ? player.subtitles : []),
+    }), [
+        player.streamState,
+        player.subtitles,
+        settings.audioLanguage,
+        settings.secondaryAudioLanguage,
+        settings.secondarySubtitlesLanguage,
+        settings.subtitlesLanguage,
+        streamSubtitles,
+    ]);
+    const onVlcStopped = React.useCallback(() => navigate(-1), [navigate]);
+    const onVlcError = React.useCallback((vlcError) => {
+        toast.show({
+            type: 'error',
+            title: t('HORIZON_VLC_FAILED'),
+            message: vlcError.message,
+            timeout: 6000,
+        });
+        navigate(-1);
+    }, [navigate, t, toast]);
+    const vlcStatus = useVlcPlayback({
+        enabled: nativeVlc && routeFocused,
+        url: vlcStreamUrl,
+        sessionKey: player.selected?.streamRequest?.path?.id ?? stream ?? null,
+        startTimeMs: vlcStartTime,
+        ...vlcPlaybackPreferences,
+        onProgress: timeChanged,
+        onCompleted: onEnded,
+        onStopped: onVlcStopped,
+        onError: onVlcError,
+    });
+
     const onError = React.useCallback((error) => {
         console.error('Player', error);
         if (error.critical) {
@@ -381,12 +434,14 @@ const Player = () => {
 
     const onAudioTrackSelected = React.useCallback((id) => {
         video.setAudioTrack(id);
+        const audioTrack = findTrackById(video.state.audioTracks, id);
         streamStateChanged({
             audioTrack: {
                 id,
+                lang: audioTrack?.lang,
             },
         });
-    }, [streamStateChanged]);
+    }, [streamStateChanged, video.state.audioTracks]);
 
     const onDismissNextVideoPopup = React.useCallback(() => {
         closeNextVideoPopup();
@@ -538,7 +593,7 @@ const Player = () => {
         cancelKeyboardSeek();
         video.unload();
 
-        if (player.selected && player.stream?.type === 'Ready' && streamingServer.settings?.type !== 'Loading') {
+        if (!nativeVlc && player.selected && player.stream?.type === 'Ready' && streamingServer.settings?.type !== 'Loading') {
             video.load({
                 stream: {
                     ...player.stream.content,
@@ -566,7 +621,7 @@ const Player = () => {
                 shellTransport: platform.shell.active ? platform.shell : null,
             });
         }
-    }, [playerStreamingServerURL, player.selected, player.stream, streamSubtitles, forceTranscoding, casting, cancelKeyboardSeek, isOfflineServiceStream]);
+    }, [playerStreamingServerURL, player.selected, player.stream, streamSubtitles, forceTranscoding, casting, cancelKeyboardSeek, isOfflineServiceStream, nativeVlc]);
 
     React.useEffect(() => {
         !seeking && timeChanged(video.state.time, video.state.duration, video.state.manifest?.name);
@@ -1000,6 +1055,23 @@ const Player = () => {
             onPauseRequestedDebounced.cancel();
         };
     }, []);
+
+    if (nativeVlc) {
+        return (
+            <div className={styles['player-container']}>
+                <div className={classnames(styles['layer'], styles['background-layer'])}>
+                    <img className={styles['image']} src={player?.metaItem?.content?.background} />
+                </div>
+                <div className={styles['external-player-status']}>
+                    <Icon className={styles['external-player-icon']} name={'vlc'} />
+                    <div className={styles['external-player-title']}>{t('HORIZON_PLAYING_IN_VLC')}</div>
+                    <div className={styles['external-player-description']}>
+                        {vlcStatus === 'playing' ? t('HORIZON_CLOSE_VLC_TO_RETURN') : t('HORIZON_OPENING_VLC')}
+                    </div>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div ref={playerRef} className={classnames(styles['player-container'], { [styles['overlayHidden']]: overlayHidden })}

--- a/src/routes/Player/styles.less
+++ b/src/routes/Player/styles.less
@@ -33,6 +33,38 @@ html:not(.active-slider-within) {
     height: 100%;
     background-color: @background-color;
 
+    .external-player-status {
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.75rem;
+        padding: 2rem;
+        text-align: center;
+        background: rgba(0, 0, 0, 0.55);
+
+        .external-player-icon {
+            width: 5rem;
+            height: 5rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .external-player-title {
+            font-size: 1.6rem;
+            font-weight: 700;
+            color: var(--primary-foreground-color);
+        }
+
+        .external-player-description {
+            max-width: 32rem;
+            font-size: 1rem;
+            color: @color-surface-light5-80;
+        }
+    }
+
     .layer {
         position: absolute;
         top: 0;

--- a/src/routes/Player/useVlcPlayback.ts
+++ b/src/routes/Player/useVlcPlayback.ts
@@ -1,0 +1,133 @@
+import { useEffect, useRef, useState } from 'react';
+import { invokeTauri, listenTauri } from 'stremio/common/tauri';
+
+type VlcPlaybackProgress = {
+    sessionId: string,
+    positionMs: number,
+    durationMs: number,
+};
+
+type VlcPlaybackResult = VlcPlaybackProgress & {
+    completed: boolean,
+};
+
+type VlcPlaybackRequest = {
+    sessionId: string,
+    url: string,
+    startTimeMs: number,
+    audioLanguage: string | null,
+    subtitleLanguage: string | null,
+    subtitleUrl: string | null,
+    subtitlesEnabled: boolean,
+};
+
+type VlcPlaybackStatus = 'idle' | 'launching' | 'playing' | 'failed';
+
+type Options = {
+    enabled: boolean,
+    url: string | null,
+    sessionKey: string | null,
+    startTimeMs: number,
+    audioLanguage: string | null,
+    subtitleLanguage: string | null,
+    subtitleUrl: string | null,
+    subtitlesEnabled: boolean,
+    onProgress: (positionMs: number, durationMs: number, device: string) => void,
+    onCompleted: () => void,
+    onStopped: () => void,
+    onError: (error: Error) => void,
+};
+
+const useVlcPlayback = ({
+    enabled,
+    url,
+    sessionKey,
+    startTimeMs,
+    audioLanguage,
+    subtitleLanguage,
+    subtitleUrl,
+    subtitlesEnabled,
+    onProgress,
+    onCompleted,
+    onStopped,
+    onError,
+}: Options): VlcPlaybackStatus => {
+    const [status, setStatus] = useState<VlcPlaybackStatus>('idle');
+    const launchedKeyRef = useRef<string | null>(null);
+    const callbacksRef = useRef({ onProgress, onCompleted, onStopped, onError });
+    callbacksRef.current = { onProgress, onCompleted, onStopped, onError };
+
+    useEffect(() => {
+        if (!enabled || url === null || sessionKey === null || launchedKeyRef.current === sessionKey) {
+            return undefined;
+        }
+
+        launchedKeyRef.current = sessionKey;
+        const sessionId = `${sessionKey}:${Date.now()}`;
+        let active = true;
+        let unlisten: (() => Promise<void>) | null = null;
+        const stopListening = async () => {
+            const listener = unlisten;
+            unlisten = null;
+            if (listener !== null) {
+                await listener().catch(() => undefined);
+            }
+        };
+
+        const run = async () => {
+            setStatus('launching');
+            try {
+                unlisten = await listenTauri<VlcPlaybackProgress>('vlc-playback-progress', ({ payload }) => {
+                    if (!active || payload.sessionId !== sessionId) return;
+                    setStatus('playing');
+                    if (payload.durationMs > 0) {
+                        callbacksRef.current.onProgress(payload.positionMs, payload.durationMs, 'VLC');
+                    }
+                });
+                if (!active) {
+                    await stopListening();
+                    return;
+                }
+
+                const result = await invokeTauri<VlcPlaybackResult, { request: VlcPlaybackRequest }>('vlc_play', {
+                    request: {
+                        sessionId,
+                        url,
+                        startTimeMs,
+                        audioLanguage,
+                        subtitleLanguage,
+                        subtitleUrl,
+                        subtitlesEnabled,
+                    },
+                });
+                if (!active) return;
+
+                if (result.durationMs > 0) {
+                    callbacksRef.current.onProgress(result.positionMs, result.durationMs, 'VLC');
+                }
+                if (result.completed) {
+                    callbacksRef.current.onCompleted();
+                } else {
+                    callbacksRef.current.onStopped();
+                }
+            } catch (error) {
+                if (!active) return;
+                setStatus('failed');
+                callbacksRef.current.onError(error instanceof Error ? error : new Error(String(error)));
+            } finally {
+                await stopListening();
+            }
+        };
+
+        run();
+
+        return () => {
+            active = false;
+            stopListening();
+        };
+    }, [audioLanguage, enabled, sessionKey, subtitleLanguage, subtitleUrl, subtitlesEnabled, url]);
+
+    return status;
+};
+
+export default useVlcPlayback;

--- a/src/routes/Player/vlcPlaybackPreferences.ts
+++ b/src/routes/Player/vlcPlaybackPreferences.ts
@@ -1,0 +1,110 @@
+import * as languages from 'stremio/common/languages';
+
+type Subtitle = {
+    id: string,
+    lang?: string | null,
+    url?: string | null,
+    fallbackUrl?: string | null,
+};
+
+type SavedSubtitle = {
+    id?: string | null,
+    embedded?: boolean,
+    lang?: string | null,
+} | null | undefined;
+
+type Options = {
+    audioLanguage?: string | null,
+    secondaryAudioLanguage?: string | null,
+    subtitlesLanguage?: string | null,
+    secondarySubtitlesLanguage?: string | null,
+    savedAudioLanguage?: string | null,
+    savedSubtitle?: SavedSubtitle,
+    subtitles?: Subtitle[] | null,
+};
+
+type VlcPlaybackPreferences = {
+    audioLanguage: string | null,
+    subtitleLanguage: string | null,
+    subtitleUrl: string | null,
+    subtitlesEnabled: boolean,
+};
+
+const normalizeLanguage = (language?: string | null): string | null => {
+    if (typeof language !== 'string' || language.trim().length === 0) {
+        return null;
+    }
+
+    return languages.toCode(language.trim());
+};
+
+const languageList = (...values: (string | null | undefined)[]): string[] => {
+    return values.reduce<string[]>((result, value) => {
+        const normalized = normalizeLanguage(value);
+        if (normalized !== null && !result.includes(normalized)) {
+            result.push(normalized);
+        }
+        return result;
+    }, []);
+};
+
+const usableSubtitleUrl = (subtitle?: Subtitle): string | null => {
+    const candidate = subtitle?.url || subtitle?.fallbackUrl;
+    if (typeof candidate !== 'string') return null;
+
+    try {
+        const parsed = new URL(candidate);
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? candidate : null;
+    } catch {
+        return null;
+    }
+};
+
+const sameLanguage = (subtitle: Subtitle, language: string): boolean => {
+    return normalizeLanguage(subtitle.lang) === language;
+};
+
+const buildVlcPlaybackPreferences = ({
+    audioLanguage,
+    secondaryAudioLanguage,
+    subtitlesLanguage,
+    secondarySubtitlesLanguage,
+    savedAudioLanguage,
+    savedSubtitle,
+    subtitles,
+}: Options): VlcPlaybackPreferences => {
+    const audioLanguages = languageList(savedAudioLanguage, audioLanguage, secondaryAudioLanguage);
+    const subtitlesEnabled = subtitlesLanguage !== null;
+
+    if (!subtitlesEnabled) {
+        return {
+            audioLanguage: audioLanguages.join(',') || null,
+            subtitleLanguage: null,
+            subtitleUrl: null,
+            subtitlesEnabled: false,
+        };
+    }
+
+    const subtitleLanguages = languageList(
+        savedSubtitle?.lang,
+        subtitlesLanguage,
+        secondarySubtitlesLanguage,
+    );
+    const availableSubtitles = Array.isArray(subtitles) ? subtitles : [];
+    const savedExternalSubtitle = savedSubtitle?.embedded === false && savedSubtitle.id ?
+        availableSubtitles.find(({ id }) => id === savedSubtitle.id)
+        :
+        undefined;
+    const preferredSubtitle = savedExternalSubtitle ?? subtitleLanguages.reduce<Subtitle | undefined>((match, language) => {
+        return match ?? availableSubtitles.find((subtitle) => usableSubtitleUrl(subtitle) !== null && sameLanguage(subtitle, language));
+    }, undefined);
+
+    return {
+        audioLanguage: audioLanguages.join(',') || null,
+        subtitleLanguage: subtitleLanguages.join(',') || null,
+        subtitleUrl: usableSubtitleUrl(preferredSubtitle),
+        subtitlesEnabled: true,
+    };
+};
+
+export default buildVlcPlaybackPreferences;

--- a/src/routes/Settings/Player/usePlayerOptions.ts
+++ b/src/routes/Settings/Player/usePlayerOptions.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCore } from 'stremio/core';
 import { CONSTANTS, languageNames, useLanguageSorting, usePlatform } from 'stremio/common';
+import { isTauri } from 'stremio/common/tauri';
 
 const LANGUAGES_NAMES: Record<string, string> = languageNames;
 
@@ -205,7 +206,11 @@ const usePlayerOptions = (profile: Profile) => {
 
     const playInExternalPlayerSelect = useMemo(() => ({
         options: CONSTANTS.EXTERNAL_PLAYERS
-            .filter(({ platforms }) => platforms.includes(platform.name))
+            .filter(({ platforms, value }) => {
+                if (!platforms.includes(platform.name)) return false;
+                const desktopVlc = value === 'vlc' && ['windows', 'linux', 'macos'].includes(platform.name);
+                return !desktopVlc || isTauri();
+            })
             .map(({ label, value }) => ({
                 value,
                 label: t(label),

--- a/tests/getFirstUnwatchedVideo.spec.js
+++ b/tests/getFirstUnwatchedVideo.spec.js
@@ -1,0 +1,70 @@
+/* global describe, expect, test */
+
+const getFirstUnwatchedVideo = require('../src/routes/MetaDetails/VideosList/getFirstUnwatchedVideo');
+
+const released = new Date('2026-01-01T00:00:00.000Z');
+const episode = (id, season, number, watched = false, overrides = {}) => ({
+    id,
+    season,
+    episode: number,
+    watched,
+    released,
+    upcoming: false,
+    ...overrides,
+});
+
+describe('getFirstUnwatchedVideo', () => {
+    test('returns the first released unwatched regular episode in story order', () => {
+        const videos = [
+            episode('s2e1', 2, 1),
+            episode('s1e2', 1, 2),
+            episode('s1e1', 1, 1, true),
+        ];
+
+        expect(getFirstUnwatchedVideo(videos)?.id).toBe('s1e2');
+    });
+
+    test('ignores upcoming and unreleased episodes', () => {
+        const videos = [
+            episode('upcoming', 1, 2, false, { upcoming: true }),
+            episode('unreleased', 1, 3, false, { released: null }),
+            episode('available', 1, 4),
+        ];
+
+        expect(getFirstUnwatchedVideo(videos)?.id).toBe('available');
+    });
+
+    test('prefers regular episodes over specials', () => {
+        const videos = [
+            episode('special', 0, 1),
+            episode('regular', 1, 1),
+        ];
+
+        expect(getFirstUnwatchedVideo(videos)?.id).toBe('regular');
+    });
+
+    test('uses unwatched specials after all regular episodes are watched', () => {
+        const videos = [
+            episode('special', 0, 1),
+            episode('regular', 1, 1, true),
+        ];
+
+        expect(getFirstUnwatchedVideo(videos)?.id).toBe('special');
+    });
+
+    test('restricts the result to an explicitly selected season', () => {
+        const videos = [
+            episode('s1e2', 1, 2),
+            episode('s2e1', 2, 1),
+        ];
+
+        expect(getFirstUnwatchedVideo(videos, 2)?.id).toBe('s2e1');
+    });
+
+    test('returns null when every released episode is watched', () => {
+        expect(getFirstUnwatchedVideo([
+            episode('s1e1', 1, 1, true),
+            episode('s1e2', 1, 2, true),
+        ])).toBeNull();
+    });
+});

--- a/tests/vlcPlaybackPreferences.spec.ts
+++ b/tests/vlcPlaybackPreferences.spec.ts
@@ -1,0 +1,56 @@
+import buildVlcPlaybackPreferences from '../src/routes/Player/vlcPlaybackPreferences';
+
+describe('VLC playback preferences', () => {
+    test('uses the app audio and subtitle languages and picks a matching subtitle URL', () => {
+        expect(buildVlcPlaybackPreferences({
+            audioLanguage: 'fre',
+            secondaryAudioLanguage: 'eng',
+            subtitlesLanguage: 'fre',
+            secondarySubtitlesLanguage: 'eng',
+            subtitles: [
+                { id: 'english', lang: 'eng', url: 'https://example.com/en.srt' },
+                { id: 'french', lang: 'fre', url: 'https://example.com/fr.srt' },
+            ],
+        })).toEqual({
+            audioLanguage: 'fra,eng',
+            subtitleLanguage: 'fra,eng',
+            subtitleUrl: 'https://example.com/fr.srt',
+            subtitlesEnabled: true,
+        });
+    });
+
+    test('keeps a previously selected external subtitle ahead of language defaults', () => {
+        expect(buildVlcPlaybackPreferences({
+            audioLanguage: 'eng',
+            subtitlesLanguage: 'fre',
+            savedSubtitle: { id: 'chosen', embedded: false, lang: 'spa' },
+            subtitles: [
+                { id: 'french', lang: 'fre', url: 'https://example.com/fr.srt' },
+                { id: 'chosen', lang: 'spa', fallbackUrl: 'https://example.com/es.srt' },
+            ],
+        })).toMatchObject({
+            subtitleLanguage: 'spa,fra',
+            subtitleUrl: 'https://example.com/es.srt',
+        });
+    });
+
+    test('turns VLC subtitles off when they are disabled in the app', () => {
+        expect(buildVlcPlaybackPreferences({
+            audioLanguage: 'eng',
+            subtitlesLanguage: null,
+            subtitles: [{ id: 'english', lang: 'eng', url: 'https://example.com/en.srt' }],
+        })).toEqual({
+            audioLanguage: 'eng',
+            subtitleLanguage: null,
+            subtitleUrl: null,
+            subtitlesEnabled: false,
+        });
+    });
+
+    test('does not pass unsafe subtitle URLs to the desktop process', () => {
+        expect(buildVlcPlaybackPreferences({
+            subtitlesLanguage: 'eng',
+            subtitles: [{ id: 'local', lang: 'eng', url: 'file:///tmp/subtitle.srt' }],
+        }).subtitleUrl).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

- open series on the season containing the first released unwatched episode and scroll it into view
- add VLC as a default-capable native desktop player
- synchronize VLC resume position, progress and watched completion with Stremio
- pass primary/secondary audio and subtitle languages plus selected external subtitles to VLC
- release the frontend as v0.1.9

## Validation

- 25 Jest suites, 156 tests
- `pnpm lint`
- production webpack build
- native VLC playback validation on macOS