### PR TITLE
fix: persist VLC watched completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-08-30
+
+### Fixed
+
+- Explicitly mark VLC playback as watched when it reaches completion so the state is preserved
+  before advancing to the next episode or leaving the player
+
 ## [0.1.9] - 2026-08-29
 
 ### Added
@@ -184,7 +191,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Lucide icons with stremio-icons fallback
 - Chromecast support (Chrome + Tauri native)
 
-[Unreleased]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.9...HEAD
+[Unreleased]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.10...HEAD
+[0.1.10]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/Aqu1tain/stremio-horizon/compare/v0.1.6...v0.1.7

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "stremio",
     "displayName": "Stremio",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "upstreamVersion": "v5.0.0-beta.39",
     "author": "Smart Code OOD",
     "private": true,

--- a/src/routes/Player/Player.js
+++ b/src/routes/Player/Player.js
@@ -73,7 +73,7 @@ const Player = () => {
     }, [queryParams]);
     const profile = useProfile();
     const nativeVlc = isTauri() && profile.settings.playerType === 'vlc';
-    const [player, videoParamsChanged, streamStateChanged, timeChanged, seek, pausedChanged, ended, nextVideo] = usePlayer(urlParams);
+    const [player, videoParamsChanged, streamStateChanged, timeChanged, seek, pausedChanged, ended, nextVideo, markVideoAsWatched] = usePlayer(urlParams);
     const downloadContext = React.useMemo(() => {
         const meta = player.metaItem?.type === 'Ready' ? player.metaItem.content : null;
         const selectedVideoId = player.selected?.streamRequest?.path?.id ?? videoId ?? null;
@@ -299,6 +299,18 @@ const Player = () => {
         streamSubtitles,
     ]);
     const onVlcStopped = React.useCallback(() => navigate(-1), [navigate]);
+    const onVlcCompleted = React.useCallback(() => {
+        const selectedVideoId = player.selected?.streamRequest?.path?.id ?? videoId ?? null;
+        const selectedVideo = player.metaItem?.type === 'Ready' ?
+            player.metaItem.content.videos.find(({ id }) => id === selectedVideoId)
+            :
+            null;
+
+        if (selectedVideo) {
+            markVideoAsWatched(selectedVideo, true);
+        }
+        onEnded();
+    }, [markVideoAsWatched, onEnded, player.metaItem, player.selected, videoId]);
     const onVlcError = React.useCallback((vlcError) => {
         toast.show({
             type: 'error',
@@ -315,7 +327,7 @@ const Player = () => {
         startTimeMs: vlcStartTime,
         ...vlcPlaybackPreferences,
         onProgress: timeChanged,
-        onCompleted: onEnded,
+        onCompleted: onVlcCompleted,
         onStopped: onVlcStopped,
         onError: onVlcError,
     });

--- a/src/routes/Player/usePlayer.js
+++ b/src/routes/Player/usePlayer.js
@@ -155,6 +155,15 @@ const usePlayer = (urlParams) => {
             }
         }, 'player');
     }, []);
+    const markVideoAsWatched = React.useCallback((video, watched) => {
+        core.transport.dispatch({
+            action: 'Player',
+            args: {
+                action: 'MarkVideoAsWatched',
+                args: [video, watched]
+            }
+        }, 'player');
+    }, []);
 
     const streamStateChanged = React.useCallback((partialStreamState) => {
         return core.transport.dispatch({
@@ -171,7 +180,7 @@ const usePlayer = (urlParams) => {
         }, 'player');
     }, [player.streamState]);
 
-    return [player, videoParamsChanged, streamStateChanged, timeChanged, seek, pausedChanged, ended, nextVideo];
+    return [player, videoParamsChanged, streamStateChanged, timeChanged, seek, pausedChanged, ended, nextVideo, markVideoAsWatched];
 };
 
 module.exports = usePlayer;


### PR DESCRIPTION
## Summary
- explicitly mark a completed VLC movie or episode as watched before navigation
- preserve the watched state when advancing to the next episode
- release the frontend as v0.1.10

## Validation
- pnpm exec eslint src/routes/Player/Player.js src/routes/Player/usePlayer.js
- pnpm test --runInBand (156 tests)
- pnpm run build